### PR TITLE
Sync some of the changes with Bot API 7.0  Reactions

### DIFF
--- a/pyrogram/methods/messages/__init__.py
+++ b/pyrogram/methods/messages/__init__.py
@@ -55,7 +55,7 @@ from .send_media_group import SendMediaGroup
 from .send_message import SendMessage
 from .send_photo import SendPhoto
 from .send_poll import SendPoll
-from .send_reaction import SendReaction
+from .set_message_reaction import SetMessageReaction
 from .send_sticker import SendSticker
 from .send_venue import SendVenue
 from .send_video import SendVideo
@@ -110,7 +110,7 @@ class Messages(
     SearchMessagesCount,
     SearchGlobalCount,
     GetDiscussionMessage,
-    SendReaction,
+    SetMessageReaction,
     GetDiscussionReplies,
     GetDiscussionRepliesCount,
     StreamMedia,

--- a/pyrogram/methods/messages/set_message_reaction.py
+++ b/pyrogram/methods/messages/set_message_reaction.py
@@ -46,11 +46,11 @@ class SetMessageReaction:
             message_id (``int``):
                 Identifier of the target message. If the message belongs to a media group, the reaction is set to the first non-deleted message in the group instead.
 
-            emoji (List of :obj:`~pyrogram.types.ReactionType` *optional*):
+            reaction (List of :obj:`~pyrogram.types.ReactionType` *optional*):
                 New list of reaction types to set on the message.
                 Pass None as emoji (default) to retract the reaction.
 
-            big (``bool``, *optional*):
+            is_big (``bool``, *optional*):
                 Pass True to set the reaction with a big animation.
                 Defaults to False.
 

--- a/pyrogram/methods/messages/set_message_reaction.py
+++ b/pyrogram/methods/messages/set_message_reaction.py
@@ -28,9 +28,9 @@ class SetMessageReaction:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         message_id: int = None,
-        reaction: List[types.ReactionType] = [],
+        reaction: List["types.ReactionType"] = [],
         is_big: bool = False
-    ) -> bool:
+    ) -> "types.MessageReactions":
         """Use this method to change the chosen reactions on a message.
         Service messages can't be reacted to.
         Automatically forwarded messages from
@@ -55,13 +55,19 @@ class SetMessageReaction:
                 Defaults to False.
 
         Returns:
-            ``bool``: On success, True is returned.
+            :obj: `~pyrogram.types.MessageReactions`: On success, True is returned.
 
         Example:
             .. code-block:: python
 
+                # Send a reaction as a bot
+                await app.set_message_reaction(chat_id, message_id, [ReactionTypeEmoji(emoji="👍")])
+
+                # Send multiple reaction as a premium user
+                await app.set_message_reaction(chat_id, message_id, [ReactionTypeEmoji(emoji="👍"),ReactionTypeEmoji(emoji="😍")],True)
+
                 # Retract a reaction
-                await app.send_reaction(chat_id, message_id=message_id)
+                await app.set_message_reaction(chat_id, message_id=message_id)
         """
         if message_id is not None:
             r = await self.invoke(
@@ -71,7 +77,7 @@ class SetMessageReaction:
                     reaction=[
                         r.write(self)
                         for r in reaction
-                    ],
+                    ] if reaction else [raw.types.ReactionEmpty()],
                     big=is_big
                 )
             )

--- a/pyrogram/methods/messages/set_message_reaction.py
+++ b/pyrogram/methods/messages/set_message_reaction.py
@@ -20,35 +20,38 @@ from typing import Union
 from typing import List
 
 import pyrogram
-from pyrogram import raw
+from pyrogram import raw, types
 
 
-class SendReaction:
-    async def send_reaction(
+class SetMessageReaction:
+    async def set_message_reaction(
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         message_id: int = None,
-        emoji: Union[int, str, List[Union[int, str]]] = None,
-        big: bool = False
+        reaction: List[types.ReactionType] = [],
+        is_big: bool = False
     ) -> bool:
-        """Send a reaction to a message.
+        """Use this method to change the chosen reactions on a message.
+        Service messages can't be reacted to.
+        Automatically forwarded messages from
+        a channel to its discussion group have the
+        same available reactions as messages in the channel.
 
-        .. include:: /_includes/usable-by/users.rst
+        .. include:: /_includes/usable-by/users-bots.rst
 
         Parameters:
             chat_id (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the target chat.
 
             message_id (``int``):
-                Identifier of the message.
+                Identifier of the target message. If the message belongs to a media group, the reaction is set to the first non-deleted message in the group instead.
 
-            emoji (``int`` | ``str`` | List of ``int`` | ``str``, *optional*):
-                Reaction emoji.
+            emoji (List of :obj:`~pyrogram.types.ReactionType` *optional*):
+                New list of reaction types to set on the message.
                 Pass None as emoji (default) to retract the reaction.
-                Pass list of int or str to react multiple emojis.
 
             big (``bool``, *optional*):
-                Pass True to show a bigger and longer reaction.
+                Pass True to set the reaction with a big animation.
                 Defaults to False.
 
         Returns:
@@ -57,34 +60,23 @@ class SendReaction:
         Example:
             .. code-block:: python
 
-                # Send a reaction
-                await app.send_reaction(chat_id, message_id=message_id, emoji="🔥")
-
-                # Send a multiple reactions
-                await app.send_reaction(chat_id, message_id=message_id, emoji=["🔥", "❤️"])
-
                 # Retract a reaction
                 await app.send_reaction(chat_id, message_id=message_id)
         """
-        if isinstance(emoji, list):
-            emoji = [
-                raw.types.ReactionCustomEmoji(document_id=i)
-                if isinstance(i, int)
-                else raw.types.ReactionEmoji(emoticon=i)
-                for i in emoji
-            ]
-        else:
-            emoji = [raw.types.ReactionEmoji(emoticon=emoji)] if emoji else []
-
         if message_id is not None:
-            await self.invoke(
+            r = await self.invoke(
                 raw.functions.messages.SendReaction(
                     peer=await self.resolve_peer(chat_id),
                     msg_id=message_id,
-                    reaction=emoji,
-                    big=big
+                    reaction=[
+                        r.write(self)
+                        for r in reaction
+                    ],
+                    big=is_big
                 )
             )
+            for i in r.updates:
+                if isinstance(i, raw.types.UpdateMessageReactions):
+                    return types.MessageReactions._parse(self, i.reactions)
         else:
             raise ValueError("You need to pass one of message_id!")
-        return True

--- a/pyrogram/types/messages_and_media/__init__.py
+++ b/pyrogram/types/messages_and_media/__init__.py
@@ -28,7 +28,7 @@ from .message_entity import MessageEntity
 from .photo import Photo
 from .poll import Poll
 from .poll_option import PollOption
-from .reaction import Reaction
+from .reaction import Reaction, ReactionType, ReactionTypeEmoji, ReactionTypeCustomEmoji
 from .sticker import Sticker
 from .stripped_thumbnail import StrippedThumbnail
 from .thumbnail import Thumbnail
@@ -43,5 +43,6 @@ from .message_reactions import MessageReactions
 __all__ = [
     "Animation", "Audio", "Contact", "Document", "Game", "Location", "Message", "MessageEntity", "Photo", "Thumbnail",
     "StrippedThumbnail", "Poll", "PollOption", "Sticker", "Venue", "Video", "VideoNote", "Voice", "WebPage", "Dice",
-    "Reaction", "WebAppData", "MessageReactions"
+    "Reaction", "WebAppData", "MessageReactions",
+    "ReactionType", "ReactionTypeEmoji", "ReactionTypeCustomEmoji"
 ]

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -3353,17 +3353,21 @@ class Message(Object, Update):
         else:
             await self.reply(button, quote=quote)
 
-    async def react(self, emoji: str = "", big: bool = False) -> bool:
+    async def react(
+        self,
+        reaction: List["types.ReactionType"] = [],
+        is_big: bool = False
+    ) -> "types.MessageReactions":
         """Bound method *react* of :obj:`~pyrogram.types.Message`.
 
         Use as a shortcut for:
 
         .. code-block:: python
 
-            await client.send_reaction(
+            await client.set_message_reaction(
                 chat_id=chat_id,
                 message_id=message.id,
-                emoji="🔥"
+                reaction=[ReactionTypeEmoji(emoji="👍")]
             )
 
         Example:
@@ -3372,26 +3376,26 @@ class Message(Object, Update):
                 await message.react(emoji="🔥")
 
         Parameters:
-            emoji (``str``, *optional*):
-                Reaction emoji.
-                Pass "" as emoji (default) to retract the reaction.
-             
-            big (``bool``, *optional*):
-                Pass True to show a bigger and longer reaction.
+            reaction (List of :obj:`~pyrogram.types.ReactionType` *optional*):
+                New list of reaction types to set on the message.
+                Pass None as emoji (default) to retract the reaction.
+
+            is_big (``bool``, *optional*):
+                Pass True to set the reaction with a big animation.
                 Defaults to False.
 
         Returns:
-            ``bool``: On success, True is returned.
+            :obj: `~pyrogram.types.MessageReactions`: On success, True is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
         """
 
-        return await self._client.send_reaction(
+        return await self._client.set_message_reaction(
             chat_id=self.chat.id,
             message_id=self.id,
-            emoji=emoji,
-            big=big
+            reaction=reaction,
+            is_big=is_big
         )
 
     async def retract_vote(

--- a/pyrogram/types/messages_and_media/reaction.py
+++ b/pyrogram/types/messages_and_media/reaction.py
@@ -84,3 +84,59 @@ class Reaction(Object):
         reaction.chosen_order = reaction_count.chosen_order
 
         return reaction
+
+
+class ReactionType(Object):
+    def __init__(
+        self,
+        *,
+        type: str = None,
+        emoji: str = None,
+        custom_emoji_id: str = None
+    ):
+        super().__init__()
+        self.type = type
+        self.emoji = emoji
+        self.custom_emoji_id = custom_emoji_id
+
+
+    def write(self, client: "pyrogram.Client"):
+        raise NotImplementedError
+
+
+class ReactionTypeEmoji(ReactionType):
+    """The reaction is based on an emoji.
+    """
+
+    def __init__(
+        self,
+        *,
+        emoji: str = None
+    ):
+        super().__init__(
+            type="emoji",
+            emoji=emoji
+        )
+
+    def write(self, client: "pyrogram.Client") -> "raw.base.Reaction":
+        return raw.types.ReactionEmoji(
+            emoticon=self.emoji
+        )
+        
+
+class ReactionTypeCustomEmoji(ReactionType):
+
+    def __init__(
+        self,
+        *,
+        custom_emoji_id: str = None
+    ):
+        super().__init__(
+            type="custom_emoji",
+            custom_emoji_id=custom_emoji_id
+        )
+    
+    def write(self, client: "pyrogram.Client") -> "raw.base.Reaction":
+        return raw.types.ReactionCustomEmoji(
+            document_id=self.custom_emoji_id
+        )


### PR DESCRIPTION
- [ ] Added the classes [ReactionTypeEmoji](https://core.telegram.org/bots/api#reactiontypeemoji) and [ReactionTypeCustomEmoji](https://core.telegram.org/bots/api#reactiontypecustomemoji) representing different types of reaction.
- [ ] Added the method [setMessageReaction](https://core.telegram.org/bots/api#setmessagereaction) that allows bots to react to messages.
