### PR TITLE
send_as

### DIFF
--- a/docs/source/releases/changes-in-this-fork.rst
+++ b/docs/source/releases/changes-in-this-fork.rst
@@ -14,6 +14,7 @@ If you found any issue or have any suggestions, feel free to make `an issue <htt
 | Scheme layer used: 190 |
 +------------------------+
 
+- Added the parameter ``send_as`` in the appropriate methods and bound methods `PR 107 <https://github.com/TelegramPlayGround/pyrogram/pull/107>`_.
 - View `new and changed <https://telegramplayground.github.io/TG-APIs/TL/diff/tdlib.html?from=189&to=190>`__ `raw API methods <https://telegramplayground.github.io/TG-APIs/TL/diff/tdesktop.html?from=189&to=190>`__.
 
 +------------------------+

--- a/pyrogram/methods/bots/send_game.py
+++ b/pyrogram/methods/bots/send_game.py
@@ -34,6 +34,7 @@ class SendGame:
         protect_content: bool = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,        
         reply_markup: Union[
@@ -69,6 +70,13 @@ class SendGame:
 
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.
@@ -119,6 +127,7 @@ class SendGame:
             silent=disable_notification or None,
             reply_to=reply_to,
             random_id=self.rnd_id(),
+            send_as=await self.resolve_peer(send_as) if send_as else None,
             noforwards=protect_content,
             effect=message_effect_id,
             reply_markup=await reply_markup.write(self) if reply_markup else None

--- a/pyrogram/methods/bots/send_game.py
+++ b/pyrogram/methods/bots/send_game.py
@@ -73,10 +73,10 @@ class SendGame:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.

--- a/pyrogram/methods/bots/send_inline_bot_result.py
+++ b/pyrogram/methods/bots/send_inline_bot_result.py
@@ -33,6 +33,7 @@ class SendInlineBotResult:
         result_id: str,
         disable_notification: bool = None,
         reply_parameters: "types.ReplyParameters" = None,
+        send_as: Union[int, str] = None,
         message_thread_id: int = None,
         reply_to_message_id: int = None
     ) -> "raw.base.Updates":
@@ -59,6 +60,13 @@ class SendInlineBotResult:
 
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Description of the message to reply to
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             message_thread_id (``int``, *optional*):
                 If the message is in a thread, ID of the original message.
@@ -97,6 +105,7 @@ class SendInlineBotResult:
                 query_id=query_id,
                 id=result_id,
                 random_id=self.rnd_id(),
+                send_as=await self.resolve_peer(send_as) if send_as else None,
                 silent=disable_notification or None,
                 reply_to=reply_to
             )

--- a/pyrogram/methods/bots/send_inline_bot_result.py
+++ b/pyrogram/methods/bots/send_inline_bot_result.py
@@ -63,10 +63,10 @@ class SendInlineBotResult:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             message_thread_id (``int``, *optional*):
                 If the message is in a thread, ID of the original message.

--- a/pyrogram/methods/business/send_invoice.py
+++ b/pyrogram/methods/business/send_invoice.py
@@ -55,6 +55,7 @@ class SendInvoice:
         protect_content: bool = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
+        send_as: Union[int, str] = None,
         reply_markup: Union[
             "types.InlineKeyboardMarkup",
             "types.ReplyKeyboardMarkup",
@@ -152,6 +153,13 @@ class SendInvoice:
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Description of the message to reply to
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardRemove` | :obj:`~pyrogram.types.ForceReply`, *optional*):
                 Additional interface options. An object for an inline keyboard, custom reply keyboard,
                 instructions to remove reply keyboard or to force a reply from the user.
@@ -214,6 +222,7 @@ class SendInvoice:
             silent=disable_notification or None,
             reply_to=reply_to,
             random_id=self.rnd_id(),
+            send_as=await self.resolve_peer(send_as) if send_as else None,
             noforwards=protect_content,
             reply_markup=await reply_markup.write(self) if reply_markup else None,
             effect=message_effect_id,

--- a/pyrogram/methods/business/send_invoice.py
+++ b/pyrogram/methods/business/send_invoice.py
@@ -155,10 +155,10 @@ class SendInvoice:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardRemove` | :obj:`~pyrogram.types.ForceReply`, *optional*):
                 Additional interface options. An object for an inline keyboard, custom reply keyboard,

--- a/pyrogram/methods/messages/copy_media_group.py
+++ b/pyrogram/methods/messages/copy_media_group.py
@@ -36,6 +36,7 @@ class CopyMediaGroup:
         disable_notification: bool = None,
         reply_parameters: "types.ReplyParameters" = None,
         message_thread_id: int = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         reply_to_message_id: int = None
     ) -> List["types.Message"]:
@@ -75,6 +76,13 @@ class CopyMediaGroup:
 
             message_thread_id (``int``, *optional*):
                 If the message is in a thread, ID of the original message.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -157,6 +165,7 @@ class CopyMediaGroup:
                 multi_media=multi_media,
                 silent=disable_notification or None,
                 reply_to=reply_to,
+                send_as=await self.resolve_peer(send_as) if send_as else None,
                 schedule_date=utils.datetime_to_timestamp(schedule_date),
                 invert_media=any(show_caption_above_media)
             ),

--- a/pyrogram/methods/messages/copy_media_group.py
+++ b/pyrogram/methods/messages/copy_media_group.py
@@ -76,13 +76,13 @@ class CopyMediaGroup:
 
             message_thread_id (``int``, *optional*):
                 If the message is in a thread, ID of the original message.
-
+            
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.

--- a/pyrogram/methods/messages/copy_message.py
+++ b/pyrogram/methods/messages/copy_message.py
@@ -46,6 +46,7 @@ class CopyMessage:
         ] = None,
         schedule_date: datetime = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         protect_content: bool = None,
         message_thread_id: int = None,
         reply_to_message_id: int = None
@@ -105,6 +106,13 @@ class CopyMessage:
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             protect_content (``bool``, *optional*):
                 Pass True if the content of the message must be protected from forwarding and saving; for bots only.
 
@@ -151,6 +159,7 @@ class CopyMessage:
             reply_markup=reply_markup,
             schedule_date=schedule_date,
             business_connection_id=business_connection_id,
+            send_as=send_as,  # TODO: Implement this
             protect_content=protect_content,
             message_thread_id=message_thread_id
         )

--- a/pyrogram/methods/messages/copy_message.py
+++ b/pyrogram/methods/messages/copy_message.py
@@ -159,7 +159,7 @@ class CopyMessage:
             reply_markup=reply_markup,
             schedule_date=schedule_date,
             business_connection_id=business_connection_id,
-            send_as=send_as,  # TODO: Implement this
+            send_as=send_as,
             protect_content=protect_content,
             message_thread_id=message_thread_id
         )

--- a/pyrogram/methods/messages/copy_message.py
+++ b/pyrogram/methods/messages/copy_message.py
@@ -108,10 +108,10 @@ class CopyMessage:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             protect_content (``bool``, *optional*):
                 Pass True if the content of the message must be protected from forwarding and saving; for bots only.

--- a/pyrogram/methods/messages/forward_messages.py
+++ b/pyrogram/methods/messages/forward_messages.py
@@ -35,6 +35,7 @@ class ForwardMessages:
         protect_content: bool = None,
         drop_author: bool = None,
         drop_media_captions: bool = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None
     ) -> Union["types.Message", List["types.Message"]]:
         """Forward messages of any kind.
@@ -71,6 +72,13 @@ class ForwardMessages:
             drop_media_captions (``bool``, *optional*):
                 Whether to strip captions from media.
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
         Returns:
@@ -102,6 +110,7 @@ class ForwardMessages:
                 drop_media_captions=drop_media_captions,
                 noforwards=protect_content,
                 random_id=[self.rnd_id() for _ in message_ids],
+                send_as=await self.resolve_peer(send_as) if send_as else None,
                 schedule_date=utils.datetime_to_timestamp(schedule_date),
                 top_msg_id=message_thread_id
                 # TODO

--- a/pyrogram/methods/messages/forward_messages.py
+++ b/pyrogram/methods/messages/forward_messages.py
@@ -74,10 +74,10 @@ class ForwardMessages:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.

--- a/pyrogram/methods/messages/send_animation.py
+++ b/pyrogram/methods/messages/send_animation.py
@@ -51,6 +51,7 @@ class SendAnimation:
         reply_parameters: "types.ReplyParameters" = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         message_effect_id: int = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
@@ -133,6 +134,13 @@ class SendAnimation:
 
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.
@@ -282,6 +290,7 @@ class SendAnimation:
                 silent=disable_notification or None,
                 reply_to=reply_to,
                 random_id=self.rnd_id(),
+                send_as=await self.resolve_peer(send_as) if send_as else None,
                 schedule_date=utils.datetime_to_timestamp(schedule_date),
                 noforwards=protect_content,
                 reply_markup=await reply_markup.write(self) if reply_markup else None,

--- a/pyrogram/methods/messages/send_animation.py
+++ b/pyrogram/methods/messages/send_animation.py
@@ -137,10 +137,10 @@ class SendAnimation:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.

--- a/pyrogram/methods/messages/send_audio.py
+++ b/pyrogram/methods/messages/send_audio.py
@@ -48,6 +48,7 @@ class SendAudio:
         reply_parameters: "types.ReplyParameters" = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         message_effect_id: int = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
@@ -121,6 +122,13 @@ class SendAudio:
 
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.
@@ -251,6 +259,7 @@ class SendAudio:
                 silent=disable_notification or None,
                 reply_to=reply_to,
                 random_id=self.rnd_id(),
+                send_as=await self.resolve_peer(send_as) if send_as else None,
                 schedule_date=utils.datetime_to_timestamp(schedule_date),
                 noforwards=protect_content,
                 reply_markup=await reply_markup.write(self) if reply_markup else None,

--- a/pyrogram/methods/messages/send_audio.py
+++ b/pyrogram/methods/messages/send_audio.py
@@ -125,10 +125,10 @@ class SendAudio:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.

--- a/pyrogram/methods/messages/send_cached_media.py
+++ b/pyrogram/methods/messages/send_cached_media.py
@@ -40,6 +40,7 @@ class SendCachedMedia:
         reply_parameters: "types.ReplyParameters" = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
         has_spoiler: bool = None,
@@ -98,6 +99,13 @@ class SendCachedMedia:
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
             
@@ -144,6 +152,7 @@ class SendCachedMedia:
             silent=disable_notification or None,
             reply_to=reply_to,
             random_id=self.rnd_id(),
+            send_as=await self.resolve_peer(send_as) if send_as else None,
             schedule_date=utils.datetime_to_timestamp(schedule_date),
             noforwards=protect_content,
             reply_markup=await reply_markup.write(self) if reply_markup else None,

--- a/pyrogram/methods/messages/send_cached_media.py
+++ b/pyrogram/methods/messages/send_cached_media.py
@@ -101,10 +101,10 @@ class SendCachedMedia:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.

--- a/pyrogram/methods/messages/send_contact.py
+++ b/pyrogram/methods/messages/send_contact.py
@@ -38,6 +38,7 @@ class SendContact:
         reply_parameters: "types.ReplyParameters" = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
         message_effect_id: int = None,
@@ -83,6 +84,13 @@ class SendContact:
 
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -136,6 +144,7 @@ class SendContact:
             silent=disable_notification or None,
             reply_to=reply_to,
             random_id=self.rnd_id(),
+            send_as=await self.resolve_peer(send_as) if send_as else None,
             schedule_date=utils.datetime_to_timestamp(schedule_date),
             noforwards=protect_content,
             reply_markup=await reply_markup.write(self) if reply_markup else None,

--- a/pyrogram/methods/messages/send_contact.py
+++ b/pyrogram/methods/messages/send_contact.py
@@ -87,10 +87,10 @@ class SendContact:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.

--- a/pyrogram/methods/messages/send_dice.py
+++ b/pyrogram/methods/messages/send_dice.py
@@ -35,6 +35,7 @@ class SendDice:
         reply_parameters: "types.ReplyParameters" = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
         message_effect_id: int = None,
@@ -75,6 +76,13 @@ class SendDice:
 
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -129,6 +137,7 @@ class SendDice:
             silent=disable_notification or None,
             reply_to=reply_to,
             random_id=self.rnd_id(),
+            send_as=await self.resolve_peer(send_as) if send_as else None,
             schedule_date=utils.datetime_to_timestamp(schedule_date),
             noforwards=protect_content,
             reply_markup=await reply_markup.write(self) if reply_markup else None,

--- a/pyrogram/methods/messages/send_dice.py
+++ b/pyrogram/methods/messages/send_dice.py
@@ -79,10 +79,10 @@ class SendDice:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.

--- a/pyrogram/methods/messages/send_document.py
+++ b/pyrogram/methods/messages/send_document.py
@@ -46,6 +46,7 @@ class SendDocument:
         reply_parameters: "types.ReplyParameters" = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         message_effect_id: int = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
@@ -115,6 +116,13 @@ class SendDocument:
 
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.
@@ -243,6 +251,7 @@ class SendDocument:
                 silent=disable_notification or None,
                 reply_to=reply_to,
                 random_id=self.rnd_id(),
+                send_as=await self.resolve_peer(send_as) if send_as else None,
                 schedule_date=utils.datetime_to_timestamp(schedule_date),
                 noforwards=protect_content,
                 reply_markup=await reply_markup.write(self) if reply_markup else None,

--- a/pyrogram/methods/messages/send_document.py
+++ b/pyrogram/methods/messages/send_document.py
@@ -119,10 +119,10 @@ class SendDocument:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.

--- a/pyrogram/methods/messages/send_location.py
+++ b/pyrogram/methods/messages/send_location.py
@@ -39,6 +39,7 @@ class SendLocation:
         reply_parameters: "types.ReplyParameters" = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
         message_effect_id: int = None,
@@ -81,6 +82,13 @@ class SendLocation:
 
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -135,6 +143,7 @@ class SendLocation:
             silent=disable_notification or None,
             reply_to=reply_to,
             random_id=self.rnd_id(),
+            send_as=await self.resolve_peer(send_as) if send_as else None,
             schedule_date=utils.datetime_to_timestamp(schedule_date),
             noforwards=protect_content,
             reply_markup=await reply_markup.write(self) if reply_markup else None,

--- a/pyrogram/methods/messages/send_location.py
+++ b/pyrogram/methods/messages/send_location.py
@@ -85,10 +85,10 @@ class SendLocation:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.

--- a/pyrogram/methods/messages/send_media_group.py
+++ b/pyrogram/methods/messages/send_media_group.py
@@ -45,6 +45,7 @@ class SendMediaGroup:
         reply_parameters: "types.ReplyParameters" = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
         message_effect_id: int = None,
@@ -75,6 +76,13 @@ class SendMediaGroup:
 
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -448,6 +456,7 @@ class SendMediaGroup:
             multi_media=multi_media,
             silent=disable_notification or None,
             reply_to=reply_to,
+            send_as=await self.resolve_peer(send_as) if send_as else None,
             schedule_date=utils.datetime_to_timestamp(schedule_date),
             noforwards=protect_content,
             effect=message_effect_id,

--- a/pyrogram/methods/messages/send_media_group.py
+++ b/pyrogram/methods/messages/send_media_group.py
@@ -79,10 +79,10 @@ class SendMediaGroup:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.

--- a/pyrogram/methods/messages/send_message.py
+++ b/pyrogram/methods/messages/send_message.py
@@ -39,6 +39,7 @@ class SendMessage:
         protect_content: bool = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
         reply_markup: Union[
@@ -86,6 +87,13 @@ class SendMessage:
 
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.
@@ -197,6 +205,7 @@ class SendMessage:
                     silent=disable_notification or None,
                     reply_to=reply_to,
                     random_id=self.rnd_id(),
+                    send_as=await self.resolve_peer(send_as) if send_as else None,
                     schedule_date=utils.datetime_to_timestamp(schedule_date),
                     reply_markup=await reply_markup.write(self) if reply_markup else None,
                     message=message,
@@ -252,6 +261,7 @@ class SendMessage:
                     reply_markup=await reply_markup.write(self) if reply_markup else None,
                     # TODO
                     random_id=self.rnd_id(),
+                    send_as=await self.resolve_peer(send_as) if send_as else None,
                     message=message,
                     entities=entities,
                     # TODO
@@ -283,6 +293,7 @@ class SendMessage:
                 reply_markup=await reply_markup.write(self) if reply_markup else None,
                 # TODO
                 random_id=self.rnd_id(),
+                send_as=await self.resolve_peer(send_as) if send_as else None,
                 message=message,
                 entities=entities,
                 # TODO

--- a/pyrogram/methods/messages/send_message.py
+++ b/pyrogram/methods/messages/send_message.py
@@ -90,10 +90,10 @@ class SendMessage:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.
@@ -259,7 +259,6 @@ class SendMessage:
                     reply_to=reply_to,
                     schedule_date=utils.datetime_to_timestamp(schedule_date),
                     reply_markup=await reply_markup.write(self) if reply_markup else None,
-                    # TODO
                     random_id=self.rnd_id(),
                     send_as=await self.resolve_peer(send_as) if send_as else None,
                     message=message,
@@ -291,7 +290,6 @@ class SendMessage:
                 reply_to=reply_to,
                 schedule_date=utils.datetime_to_timestamp(schedule_date),
                 reply_markup=await reply_markup.write(self) if reply_markup else None,
-                # TODO
                 random_id=self.rnd_id(),
                 send_as=await self.resolve_peer(send_as) if send_as else None,
                 message=message,

--- a/pyrogram/methods/messages/send_paid_media.py
+++ b/pyrogram/methods/messages/send_paid_media.py
@@ -100,10 +100,10 @@ class SendPaidMedia:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardRemove` | :obj:`~pyrogram.types.ForceReply`, *optional*):
                 Additional interface options. An object for an inline keyboard, custom reply keyboard,
@@ -271,6 +271,7 @@ class SendPaidMedia:
             random_id=self.rnd_id(),
             send_as=await self.resolve_peer(send_as) if send_as else None,
             schedule_date=utils.datetime_to_timestamp(schedule_date),
+            reply_markup=await reply_markup.write(self) if reply_markup else None,
             noforwards=protect_content,
             invert_media=show_caption_above_media,
             **await utils.parse_text_entities(self, caption, parse_mode, caption_entities)

--- a/pyrogram/methods/messages/send_paid_media.py
+++ b/pyrogram/methods/messages/send_paid_media.py
@@ -46,6 +46,7 @@ class SendPaidMedia:
         protect_content: bool = None,
         reply_parameters: "types.ReplyParameters" = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         reply_markup: Union[
             "types.InlineKeyboardMarkup",
             "types.ReplyKeyboardMarkup",
@@ -96,6 +97,13 @@ class SendPaidMedia:
             
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardRemove` | :obj:`~pyrogram.types.ForceReply`, *optional*):
                 Additional interface options. An object for an inline keyboard, custom reply keyboard,
@@ -261,6 +269,7 @@ class SendPaidMedia:
             ),
             silent=disable_notification or None,
             random_id=self.rnd_id(),
+            send_as=await self.resolve_peer(send_as) if send_as else None,
             schedule_date=utils.datetime_to_timestamp(schedule_date),
             noforwards=protect_content,
             invert_media=show_caption_above_media,

--- a/pyrogram/methods/messages/send_photo.py
+++ b/pyrogram/methods/messages/send_photo.py
@@ -46,6 +46,7 @@ class SendPhoto:
         reply_parameters: "types.ReplyParameters" = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
         view_once: bool = None,
@@ -109,6 +110,13 @@ class SendPhoto:
 
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -225,6 +233,7 @@ class SendPhoto:
                 silent=disable_notification or None,
                 reply_to=reply_to,
                 random_id=self.rnd_id(),
+                send_as=await self.resolve_peer(send_as) if send_as else None,
                 schedule_date=utils.datetime_to_timestamp(schedule_date),
                 noforwards=protect_content,
                 reply_markup=await reply_markup.write(self) if reply_markup else None,

--- a/pyrogram/methods/messages/send_photo.py
+++ b/pyrogram/methods/messages/send_photo.py
@@ -113,10 +113,10 @@ class SendPhoto:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.

--- a/pyrogram/methods/messages/send_poll.py
+++ b/pyrogram/methods/messages/send_poll.py
@@ -49,6 +49,7 @@ class SendPoll:
         reply_parameters: "types.ReplyParameters" = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         message_effect_id: int = None,
         reply_markup: Union[
@@ -138,6 +139,13 @@ class SendPoll:
 
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -238,6 +246,7 @@ class SendPoll:
             silent=disable_notification,
             reply_to=reply_to,
             random_id=self.rnd_id(),
+            send_as=await self.resolve_peer(send_as) if send_as else None,
             schedule_date=utils.datetime_to_timestamp(schedule_date),
             noforwards=protect_content,
             reply_markup=await reply_markup.write(self) if reply_markup else None,

--- a/pyrogram/methods/messages/send_poll.py
+++ b/pyrogram/methods/messages/send_poll.py
@@ -142,10 +142,10 @@ class SendPoll:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.

--- a/pyrogram/methods/messages/send_sticker.py
+++ b/pyrogram/methods/messages/send_sticker.py
@@ -44,6 +44,7 @@ class SendSticker:
         protect_content: bool = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
         reply_markup: Union[
@@ -99,6 +100,13 @@ class SendSticker:
 
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.
@@ -216,6 +224,7 @@ class SendSticker:
                 reply_to=reply_to,
                 media=media,
                 random_id=self.rnd_id(),
+                send_as=await self.resolve_peer(send_as) if send_as else None,
                 reply_markup=await reply_markup.write(self) if reply_markup else None,
                 schedule_date=utils.datetime_to_timestamp(schedule_date),
 

--- a/pyrogram/methods/messages/send_sticker.py
+++ b/pyrogram/methods/messages/send_sticker.py
@@ -103,10 +103,10 @@ class SendSticker:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.

--- a/pyrogram/methods/messages/send_venue.py
+++ b/pyrogram/methods/messages/send_venue.py
@@ -42,6 +42,7 @@ class SendVenue:
         reply_parameters: "types.ReplyParameters" = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
         message_effect_id: int = None,
@@ -94,6 +95,13 @@ class SendVenue:
 
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -155,6 +163,7 @@ class SendVenue:
             silent=disable_notification or None,
             reply_to=reply_to,
             random_id=self.rnd_id(),
+            send_as=await self.resolve_peer(send_as) if send_as else None,
             schedule_date=utils.datetime_to_timestamp(schedule_date),
             noforwards=protect_content,
             reply_markup=await reply_markup.write(self) if reply_markup else None,

--- a/pyrogram/methods/messages/send_venue.py
+++ b/pyrogram/methods/messages/send_venue.py
@@ -98,10 +98,10 @@ class SendVenue:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.

--- a/pyrogram/methods/messages/send_video.py
+++ b/pyrogram/methods/messages/send_video.py
@@ -50,6 +50,7 @@ class SendVideo:
         protect_content: bool = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
         reply_markup: Union[
@@ -131,6 +132,13 @@ class SendVideo:
 
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.
@@ -289,6 +297,7 @@ class SendVideo:
                 silent=disable_notification or None,
                 reply_to=reply_to,
                 random_id=self.rnd_id(),
+                send_as=await self.resolve_peer(send_as) if send_as else None,
                 schedule_date=utils.datetime_to_timestamp(schedule_date),
                 noforwards=protect_content,
                 reply_markup=await reply_markup.write(self) if reply_markup else None,

--- a/pyrogram/methods/messages/send_video.py
+++ b/pyrogram/methods/messages/send_video.py
@@ -135,10 +135,10 @@ class SendVideo:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.

--- a/pyrogram/methods/messages/send_video_note.py
+++ b/pyrogram/methods/messages/send_video_note.py
@@ -42,6 +42,7 @@ class SendVideoNote:
         protect_content: bool = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
         reply_markup: Union[
@@ -101,6 +102,13 @@ class SendVideoNote:
 
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.
@@ -245,6 +253,7 @@ class SendVideoNote:
                 silent=disable_notification or None,
                 reply_to=reply_to,
                 random_id=self.rnd_id(),
+                send_as=await self.resolve_peer(send_as) if send_as else None,
                 schedule_date=utils.datetime_to_timestamp(schedule_date),
                 noforwards=protect_content,
                 reply_markup=await reply_markup.write(self) if reply_markup else None,

--- a/pyrogram/methods/messages/send_video_note.py
+++ b/pyrogram/methods/messages/send_video_note.py
@@ -105,10 +105,10 @@ class SendVideoNote:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.

--- a/pyrogram/methods/messages/send_voice.py
+++ b/pyrogram/methods/messages/send_voice.py
@@ -44,6 +44,7 @@ class SendVoice:
         protect_content: bool = None,
         message_thread_id: int = None,
         business_connection_id: str = None,
+        send_as: Union[int, str] = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
         reply_markup: Union[
@@ -102,6 +103,13 @@ class SendVoice:
 
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
+
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.
@@ -241,6 +249,7 @@ class SendVoice:
                 silent=disable_notification or None,
                 reply_to=reply_to,
                 random_id=self.rnd_id(),
+                send_as=await self.resolve_peer(send_as) if send_as else None,
                 schedule_date=utils.datetime_to_timestamp(schedule_date),
                 noforwards=protect_content,
                 reply_markup=await reply_markup.write(self) if reply_markup else None,

--- a/pyrogram/methods/messages/send_voice.py
+++ b/pyrogram/methods/messages/send_voice.py
@@ -106,10 +106,10 @@ class SendVoice:
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             message_effect_id (``int`` ``64-bit``, *optional*):
                 Unique identifier of the message effect to be added to the message; for private chats only.

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -1482,6 +1482,7 @@ class Message(Object, Update):
             "types.ReplyKeyboardRemove",
             "types.ForceReply"
         ] = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         disable_web_page_preview: bool = None,
         reply_to_message_id: int = None
@@ -1543,6 +1544,13 @@ class Message(Object, Update):
                 Additional interface options. An object for an inline keyboard, custom reply keyboard,
                 instructions to remove reply keyboard or to force a reply from the user.
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
 
@@ -1570,6 +1578,7 @@ class Message(Object, Update):
             protect_content=protect_content,
             message_thread_id=self.message_thread_id,
             business_connection_id=self.business_connection_id,
+            send_as=send_as,
             message_effect_id=message_effect_id,
             reply_parameters=reply_parameters,
             reply_markup=reply_markup,
@@ -1607,6 +1616,7 @@ class Message(Object, Update):
             "types.ReplyKeyboardRemove",
             "types.ForceReply"
         ] = None,
+        send_as: Union[int, str] = None,
         reply_to_message_id: int = None,
         progress: Callable = None,
         progress_args: tuple = ()
@@ -1688,6 +1698,13 @@ class Message(Object, Update):
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Description of the message to reply to
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
 
@@ -1759,6 +1776,7 @@ class Message(Object, Update):
             reply_parameters=reply_parameters,
             message_thread_id=self.message_thread_id,
             business_connection_id=self.business_connection_id,
+            send_as=send_as,
             schedule_date=schedule_date,
             protect_content=protect_content,
             ttl_seconds=ttl_seconds,
@@ -1783,6 +1801,7 @@ class Message(Object, Update):
         disable_notification: bool = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
         reply_markup: Union[
@@ -1862,6 +1881,13 @@ class Message(Object, Update):
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Description of the message to reply to
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
 
@@ -1926,6 +1952,7 @@ class Message(Object, Update):
             reply_parameters=reply_parameters,
             message_thread_id=self.message_thread_id,
             business_connection_id=self.business_connection_id,
+            send_as=send_as,
             schedule_date=schedule_date,
             protect_content=protect_content,
             reply_markup=reply_markup,
@@ -1945,6 +1972,7 @@ class Message(Object, Update):
         disable_notification: bool = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         reply_markup: Union[
             "types.InlineKeyboardMarkup",
@@ -2003,6 +2031,13 @@ class Message(Object, Update):
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Description of the message to reply to
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
 
@@ -2036,6 +2071,7 @@ class Message(Object, Update):
             reply_parameters=reply_parameters,
             message_thread_id=self.message_thread_id,
             business_connection_id=self.business_connection_id,
+            send_as=send_as,
             schedule_date=schedule_date,
             protect_content=self.has_protected_content,
             has_spoiler=self.has_media_spoiler,
@@ -2115,6 +2151,7 @@ class Message(Object, Update):
         disable_notification: bool = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
         reply_markup: Union[
@@ -2170,6 +2207,13 @@ class Message(Object, Update):
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Description of the message to reply to
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
 
@@ -2205,6 +2249,7 @@ class Message(Object, Update):
             reply_parameters=reply_parameters,
             message_thread_id=self.message_thread_id,
             business_connection_id=self.business_connection_id,
+            send_as=send_as,
             schedule_date=schedule_date,
             protect_content=protect_content,
             reply_markup=reply_markup,
@@ -2224,6 +2269,7 @@ class Message(Object, Update):
         disable_notification: bool = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
         reply_markup: Union[
@@ -2301,6 +2347,13 @@ class Message(Object, Update):
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Description of the message to reply to
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
 
@@ -2363,6 +2416,7 @@ class Message(Object, Update):
             reply_parameters=reply_parameters,
             message_thread_id=self.message_thread_id,
             business_connection_id=self.business_connection_id,
+            send_as=send_as,
             schedule_date=schedule_date,
             protect_content=protect_content,
             reply_markup=reply_markup,
@@ -2380,6 +2434,7 @@ class Message(Object, Update):
         protect_content: bool = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
+        send_as: Union[int, str] = None,
         reply_markup: Union[
             "types.InlineKeyboardMarkup",
             "types.ReplyKeyboardMarkup",
@@ -2423,6 +2478,13 @@ class Message(Object, Update):
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Description of the message to reply to
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             protect_content (``bool``, *optional*):
                 Pass True if the content of the message must be protected from forwarding and saving; for bots only.
 
@@ -2453,6 +2515,7 @@ class Message(Object, Update):
             protect_content=protect_content,
             message_thread_id=self.message_thread_id,
             business_connection_id=self.business_connection_id,
+            send_as=send_as,
             reply_markup=reply_markup,
             reply_to_message_id=reply_to_message_id
         )
@@ -2464,6 +2527,7 @@ class Message(Object, Update):
         quote: bool = None,
         disable_notification: bool = None,
         reply_parameters: "types.ReplyParameters" = None,
+        send_as: Union[int, str] = None,
         reply_to_message_id: int = None
     ) -> "Message":
         """Bound method *reply_inline_bot_result* of :obj:`~pyrogram.types.Message`.
@@ -2502,6 +2566,13 @@ class Message(Object, Update):
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Description of the message to reply to
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
         Returns:
             On success, the sent Message is returned.
 
@@ -2522,6 +2593,7 @@ class Message(Object, Update):
             result_id=result_id,
             disable_notification=disable_notification,
             reply_parameters=reply_parameters,
+            send_as=send_as,
             reply_to_message_id=reply_to_message_id
         )
 
@@ -2535,6 +2607,7 @@ class Message(Object, Update):
         disable_notification: bool = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
         reply_markup: Union[
@@ -2587,6 +2660,13 @@ class Message(Object, Update):
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Description of the message to reply to
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
 
@@ -2621,6 +2701,7 @@ class Message(Object, Update):
             reply_parameters=reply_parameters,
             message_thread_id=self.message_thread_id,
             business_connection_id=self.business_connection_id,
+            send_as=send_as,
             schedule_date=schedule_date,
             protect_content=protect_content,
             reply_markup=reply_markup,
@@ -2634,6 +2715,7 @@ class Message(Object, Update):
         disable_notification: bool = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
         reply_to_message_id: int = None
@@ -2675,6 +2757,13 @@ class Message(Object, Update):
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Description of the message to reply to
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
 
@@ -2704,6 +2793,7 @@ class Message(Object, Update):
             reply_parameters=reply_parameters,
             message_thread_id=self.message_thread_id,
             business_connection_id=self.business_connection_id,
+            send_as=send_as,
             schedule_date=schedule_date,
             protect_content=protect_content,
             reply_to_message_id=reply_to_message_id
@@ -2722,6 +2812,7 @@ class Message(Object, Update):
         disable_notification: bool = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
         view_once: bool = None,
@@ -2793,6 +2884,13 @@ class Message(Object, Update):
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Description of the message to reply to
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
 
@@ -2858,6 +2956,7 @@ class Message(Object, Update):
             reply_parameters=reply_parameters,
             message_thread_id=self.message_thread_id,
             business_connection_id=self.business_connection_id,
+            send_as=send_as,
             schedule_date=schedule_date,
             protect_content=protect_content,
             view_once=view_once,
@@ -2888,6 +2987,7 @@ class Message(Object, Update):
         protect_content: bool = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         reply_markup: Union[
             "types.InlineKeyboardMarkup",
@@ -2998,6 +3098,13 @@ class Message(Object, Update):
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Description of the message to reply to
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
 
@@ -3041,6 +3148,7 @@ class Message(Object, Update):
             reply_parameters=reply_parameters,
             message_thread_id=self.message_thread_id,
             business_connection_id=self.business_connection_id,
+            send_as=send_as,
             schedule_date=schedule_date,
             reply_to_message_id=reply_to_message_id,
             reply_markup=reply_markup
@@ -3064,6 +3172,7 @@ class Message(Object, Update):
             "types.ReplyKeyboardRemove",
             "types.ForceReply"
         ] = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         reply_to_message_id: int = None,
         progress: Callable = None,
@@ -3127,6 +3236,13 @@ class Message(Object, Update):
                 Additional interface options. An object for an inline keyboard, custom reply keyboard,
                 instructions to remove reply keyboard or to force a reply from the user.
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
 
@@ -3179,6 +3295,7 @@ class Message(Object, Update):
             protect_content=protect_content,
             message_thread_id=self.message_thread_id,
             business_connection_id=self.business_connection_id,
+            send_as=send_as,
             message_effect_id=message_effect_id,
             reply_parameters=reply_parameters,
             reply_markup=reply_markup,
@@ -3201,6 +3318,7 @@ class Message(Object, Update):
         disable_notification: bool = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
         reply_markup: Union[
@@ -3271,6 +3389,13 @@ class Message(Object, Update):
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Description of the message to reply to
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardRemove` | :obj:`~pyrogram.types.ForceReply`, *optional*):
                 Additional interface options. An object for an inline keyboard, custom reply keyboard,
                 instructions to remove reply keyboard or to force a reply from the user.
@@ -3302,6 +3427,7 @@ class Message(Object, Update):
             reply_parameters=reply_parameters,
             message_thread_id=self.message_thread_id,
             business_connection_id=self.business_connection_id,
+            send_as=send_as,
             schedule_date=schedule_date,
             protect_content=protect_content,
             reply_to_message_id=reply_to_message_id,
@@ -3336,6 +3462,7 @@ class Message(Object, Update):
         view_once: bool = None,
         file_name: str = None,
         mime_type: str = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         reply_to_message_id: int = None,
         progress: Callable = None,
@@ -3435,6 +3562,13 @@ class Message(Object, Update):
             mime_type (``str``, *optional*):
                 no docs!
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
 
@@ -3493,6 +3627,7 @@ class Message(Object, Update):
             protect_content=protect_content,
             message_thread_id=self.message_thread_id,
             business_connection_id=self.business_connection_id,
+            send_as=send_as,
             message_effect_id=message_effect_id,
             reply_parameters=reply_parameters,
             reply_markup=reply_markup,
@@ -3526,6 +3661,7 @@ class Message(Object, Update):
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
         caption_entities: List["types.MessageEntity"] = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         ttl_seconds: int = None,
         view_once: bool = None,
@@ -3600,6 +3736,13 @@ class Message(Object, Update):
             caption_entities (List of :obj:`~pyrogram.types.MessageEntity`):
                 List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
 
@@ -3658,6 +3801,7 @@ class Message(Object, Update):
             protect_content=protect_content,
             message_thread_id=self.message_thread_id,
             business_connection_id=self.business_connection_id,
+            send_as=send_as,
             message_effect_id=message_effect_id,
             reply_parameters=reply_parameters,
             reply_markup=reply_markup,
@@ -3690,6 +3834,7 @@ class Message(Object, Update):
             "types.ReplyKeyboardRemove",
             "types.ForceReply"
         ] = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         ttl_seconds: int = None,
         view_once: bool = None,
@@ -3756,6 +3901,13 @@ class Message(Object, Update):
                 Additional interface options. An object for an inline keyboard, custom reply keyboard,
                 instructions to remove reply keyboard or to force a reply from the user.
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
 
@@ -3818,6 +3970,7 @@ class Message(Object, Update):
             protect_content=protect_content,
             message_thread_id=self.message_thread_id,
             business_connection_id=self.business_connection_id,
+            send_as=send_as,
             message_effect_id=message_effect_id,
             reply_parameters=reply_parameters,
             reply_markup=reply_markup,
@@ -3859,6 +4012,7 @@ class Message(Object, Update):
         protect_content: bool = None,
         message_effect_id: int = None,
         reply_parameters: "types.ReplyParameters" = None,
+        send_as: Union[int, str] = None,
         reply_markup: Union[
             "types.InlineKeyboardMarkup",
             "types.ReplyKeyboardMarkup",
@@ -3956,6 +4110,13 @@ class Message(Object, Update):
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Description of the message to reply to
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardRemove` | :obj:`~pyrogram.types.ForceReply`, *optional*):
                 Additional interface options. An object for an inline keyboard, custom reply keyboard,
                 instructions to remove reply keyboard or to force a reply from the user.
@@ -4012,6 +4173,7 @@ class Message(Object, Update):
             protect_content=self.has_protected_content if protect_content is None else protect_content,
             message_effect_id=message_effect_id or self.effect_id,
             reply_parameters=reply_parameters,
+            send_as=send_as,
             reply_markup=reply_markup,
             caption=caption,
             parse_mode=parse_mode,
@@ -4293,6 +4455,7 @@ class Message(Object, Update):
         protect_content: bool = None,
         drop_author: bool = None,
         drop_media_captions: bool = None,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None
     ) -> Union["types.Message", List["types.Message"]]:
         """Bound method *forward* of :obj:`~pyrogram.types.Message`.
@@ -4334,6 +4497,13 @@ class Message(Object, Update):
             drop_media_captions (``bool``, *optional*):
                 Whether to strip captions from media.
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
 
@@ -4352,6 +4522,7 @@ class Message(Object, Update):
             protect_content=protect_content,
             drop_author=drop_author,
             drop_media_captions=drop_media_captions,
+            send_as=send_as,
             schedule_date=schedule_date
         )
 
@@ -4370,6 +4541,7 @@ class Message(Object, Update):
             "types.ReplyKeyboardRemove",
             "types.ForceReply"
         ] = object,
+        send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         business_connection_id: str = None,
         protect_content: bool = None,
@@ -4427,6 +4599,13 @@ class Message(Object, Update):
                 If not specified, the original reply markup is kept.
                 Pass None to remove the reply markup.
 
+            send_as (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the chat or channel to send the message as.
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
+                (i.e., you are the owner or an anonymous admin).
+                This setting applies to the current message and will remain effective for future messages unless explicitly changed.
+                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
 
@@ -4468,6 +4647,7 @@ class Message(Object, Update):
                 reply_parameters=reply_parameters,
                 reply_markup=self.reply_markup if reply_markup is object else reply_markup,
                 reply_to_message_id=reply_to_message_id,
+                send_as=send_as,
                 schedule_date=schedule_date
             )
         elif self.media:
@@ -4484,6 +4664,7 @@ class Message(Object, Update):
                 protect_content=self.has_protected_content if protect_content is None else protect_content,
                 has_spoiler=self.has_media_spoiler,
                 reply_to_message_id=reply_to_message_id,
+                send_as=send_as,
                 reply_markup=self.reply_markup if reply_markup is object else reply_markup
             )
 
@@ -4518,6 +4699,7 @@ class Message(Object, Update):
                     schedule_date=schedule_date,
                     protect_content=self.has_protected_content if protect_content is None else protect_content,
                     reply_to_message_id=reply_to_message_id,
+                    send_as=send_as,
                     reply_markup=self.reply_markup if reply_markup is object else reply_markup
                 )
             elif self.location:
@@ -4533,6 +4715,7 @@ class Message(Object, Update):
                     schedule_date=schedule_date,
                     protect_content=self.has_protected_content if protect_content is None else protect_content,
                     reply_to_message_id=reply_to_message_id,
+                    send_as=send_as,
                     reply_markup=self.reply_markup if reply_markup is object else reply_markup
                 )
             elif self.venue:
@@ -4552,6 +4735,7 @@ class Message(Object, Update):
                     schedule_date=schedule_date,
                     protect_content=self.has_protected_content if protect_content is None else protect_content,
                     reply_to_message_id=reply_to_message_id,
+                    send_as=send_as,
                     reply_markup=self.reply_markup if reply_markup is object else reply_markup
                 )
             elif self.poll:
@@ -4581,6 +4765,7 @@ class Message(Object, Update):
                     business_connection_id=self.business_connection_id if business_connection_id is None else business_connection_id,
                     schedule_date=schedule_date,
                     reply_to_message_id=reply_to_message_id,
+                    send_as=send_as,
                     reply_markup=self.reply_markup if reply_markup is object else reply_markup
                 )
             elif self.game:
@@ -4594,6 +4779,7 @@ class Message(Object, Update):
                     message_effect_id=self.effect_id,
                     reply_parameters=reply_parameters,
                     reply_to_message_id=reply_to_message_id,
+                    send_as=send_as,
                     reply_markup=self.reply_markup if reply_markup is object else reply_markup
                 )
             else:
@@ -4607,7 +4793,7 @@ class Message(Object, Update):
                 file_id=file_id,
                 caption=caption,
                 parse_mode=parse_mode,
-                caption_entities=caption_entities
+                caption_entities=caption_entities,
             )
         else:
             raise ValueError("Can't copy this message")

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -1546,10 +1546,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -1700,10 +1700,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -1883,10 +1883,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -2033,10 +2033,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -2209,10 +2209,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -2349,10 +2349,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -2480,10 +2480,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             protect_content (``bool``, *optional*):
                 Pass True if the content of the message must be protected from forwarding and saving; for bots only.
@@ -2568,10 +2568,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
         Returns:
             On success, the sent Message is returned.
@@ -2662,10 +2662,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -2759,10 +2759,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -2886,10 +2886,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -3100,10 +3100,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -3238,10 +3238,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -3391,10 +3391,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardRemove` | :obj:`~pyrogram.types.ForceReply`, *optional*):
                 Additional interface options. An object for an inline keyboard, custom reply keyboard,
@@ -3564,10 +3564,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -3738,10 +3738,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -3903,10 +3903,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -4112,10 +4112,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardRemove` | :obj:`~pyrogram.types.ForceReply`, *optional*):
                 Additional interface options. An object for an inline keyboard, custom reply keyboard,
@@ -4499,10 +4499,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -4601,10 +4601,10 @@ class Message(Object, Update):
 
             send_as (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the chat or channel to send the message as.
-                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions
-                (i.e., you are the owner or an anonymous admin).
+                You can use this to send the message on behalf of a chat or channel where you have appropriate permissions.
+                Use the :meth:`~pyrogram.Client.get_send_as_chats` to return the list of message sender identifiers, which can be used to send messages in the chat, 
                 This setting applies to the current message and will remain effective for future messages unless explicitly changed.
-                To set this behavior permanently for all messages, use `Client.set_send_as_chat`.
+                To set this behavior permanently for all messages, use :meth:`~pyrogram.Client.set_send_as_chat`.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.


### PR DESCRIPTION
Added feature in `send_message` to send as another chat
for eample:
```python
await app.send_message(chat_id="channel_A", text="Hi", send_as="channel_B")
```