### PR TITLE
Update utils.py: make datetime object UTC timezone aware.

### DIFF
--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -454,7 +454,7 @@ def zero_datetime() -> datetime:
 
 
 def timestamp_to_datetime(ts: Optional[int]) -> Optional[datetime]:
-    return datetime.fromtimestamp(ts) if ts else None
+    return datetime.fromtimestamp(ts).replace(tzinfo=timezone.utc) if ts else None
 
 
 def datetime_to_timestamp(dt: Optional[datetime]) -> Optional[int]:


### PR DESCRIPTION
datetime.utcnow() is deprecated in py 3.12+ and it is recommended to use datetime.now(UTC)

it creates a timezone aware object and pyrogram's previous datetime object was timezone naive which resulted in:

TypeError: can't subtract offset-naive and offset-aware datetimes.