### PR TITLE
Drop support for 3.7 and 3.8

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.10'
 
     - name: Install dependencies AND Build Documentation
       env:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-14]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/scrape-errors.yml
+++ b/.github/workflows/scrape-errors.yml
@@ -8,13 +8,13 @@ jobs:
     name: scrape-errors
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: scrape
       run: |

--- a/compiler/api/compiler.py
+++ b/compiler/api/compiler.py
@@ -22,7 +22,7 @@ import re
 import shutil
 from functools import partial
 from pathlib import Path
-from typing import NamedTuple, List, Tuple
+from typing import NamedTuple
 
 # from autoflake import fix_code
 # from black import format_str, FileMode
@@ -82,7 +82,7 @@ class Combinator(NamedTuple):
     name: str
     id: str
     has_flags: bool
-    args: List[Tuple[str, str]]
+    args: list[tuple[str, str]]
     qualtype: str
     typespace: str
     type: str
@@ -127,7 +127,7 @@ def get_type_hint(type: str) -> str:
         is_core = True
 
         sub_type = type.split("<")[1][:-1]
-        type = f"List[{get_type_hint(sub_type)}]"
+        type = f"list[{get_type_hint(sub_type)}]"
 
     if is_core:
         return f"Optional[{type}] = None" if is_flag else type

--- a/compiler/api/template/combinator.txt
+++ b/compiler/api/template/combinator.txt
@@ -5,7 +5,7 @@ from io import BytesIO
 from pyrogram.raw.core.primitives import Int, Long, Int128, Int256, Bool, Bytes, String, Double, Vector
 from pyrogram.raw.core import TLObject
 from pyrogram import raw
-from typing import List, Optional, Any
+from typing import Optional, Any
 
 {warning}
 
@@ -14,7 +14,7 @@ class {name}(TLObject):  # type: ignore
     """{docstring}
     """
 
-    __slots__: List[str] = [{slots}]
+    __slots__: list[str] = [{slots}]
 
     ID = {id}
     QUALNAME = "{qualname}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "SpEcHIDe", email = "pyrogram@iamidiotareyoutoo.com" }]
 dependencies = ["pyaes<=1.6.1", "pysocks<=1.7.1"]
 readme = "README.md"
 license = "LGPL-3.0-or-later"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -15,8 +15,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ path = "pyrogram/__init__.py"
 [project.urls]
 Homepage = "https://telegramplayground.github.io/pyrogram/"
 Tracker = "https://github.com/TelegramPlayGround/Pyrogram/issues"
+community = "https://t.me/PyroTGFork"
 Source = "https://github.com/TelegramPlayGround/Pyrogram"
 Documentation = "https://telegramplayground.github.io/pyrogram/releases/changes-in-this-fork.html"
 
@@ -97,6 +98,6 @@ docs = [
 ]
 
 fast = [
-    "PyTgCrypto==1.2.6",
+    "PyTgCrypto>1.2.9.2,<=1.4",
     "uvloop>0.18.0,<=0.19.0"
 ]

--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -32,7 +32,7 @@ from importlib import import_module
 from io import StringIO, BytesIO
 from mimetypes import MimeTypes
 from pathlib import Path
-from typing import Union, List, Optional, Callable, AsyncGenerator, Type, Tuple
+from typing import Union, Optional, Callable, AsyncGenerator
 
 import pyrogram
 from pyrogram import __version__, __license__
@@ -287,7 +287,7 @@ class Client(Methods):
         client_platform: enums.ClientPlatform = enums.ClientPlatform.OTHER,
         link_preview_options: "types.LinkPreviewOptions" = None,
         fetch_replies: int = 1,
-        _un_docu_gnihts: List = []
+        _un_docu_gnihts: list = []
     ):
         super().__init__()
 
@@ -560,7 +560,7 @@ class Client(Methods):
 
         self.parse_mode = parse_mode
 
-    async def fetch_peers(self, peers: List[Union[raw.types.User, raw.types.Chat, raw.types.Channel]]) -> bool:
+    async def fetch_peers(self, peers: list[Union[raw.types.User, raw.types.Chat, raw.types.Channel]]) -> bool:
         is_min = False
         parsed_peers = []
 
@@ -711,7 +711,7 @@ class Client(Methods):
         elif isinstance(updates, raw.types.UpdatesTooLong):
             log.info(updates)
 
-    async def recover_gaps(self) -> Tuple[int, int]:
+    async def recover_gaps(self) -> tuple[int, int]:
         states = await self.storage.update_state()
 
         message_updates_counter = 0

--- a/pyrogram/errors/rpc_error.py
+++ b/pyrogram/errors/rpc_error.py
@@ -20,7 +20,7 @@ from os import environ
 import re
 from datetime import datetime
 from importlib import import_module
-from typing import Type, Union
+from typing import Union
 
 from pyrogram import __version__, raw
 from pyrogram.raw.core import TLObject
@@ -71,7 +71,7 @@ class RPCError(Exception):
                 f.write(f"{datetime.now()}\t{value}\t{rpc_name}\n")
 
     @staticmethod
-    def raise_it(rpc_error: "raw.types.RpcError", rpc_type: Type[TLObject]):
+    def raise_it(rpc_error: "raw.types.RpcError", rpc_type: type[TLObject]):
         error_code = rpc_error.error_code
         is_signed = error_code < 0
         error_message = rpc_error.error_message

--- a/pyrogram/file_id.py
+++ b/pyrogram/file_id.py
@@ -23,7 +23,6 @@ import struct
 import typing
 from enum import IntEnum
 from io import BytesIO
-from typing import List
 
 from pyrogram.raw.core import Bytes, String
 
@@ -64,7 +63,7 @@ def rle_encode(s: bytes) -> bytes:
     Returns:
         ``bytes``: The encoded bytes
     """
-    r: List[int] = []
+    r: list[int] = []
     n: int = 0
 
     for b in s:
@@ -92,7 +91,7 @@ def rle_decode(s: bytes) -> bytes:
     Returns:
         ``bytes``: The decoded bytes
     """
-    r: List[int] = []
+    r: list[int] = []
     z: bool = False
 
     for b in s:

--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -18,7 +18,7 @@
 
 import inspect
 import re
-from typing import Any, Callable, List, Literal, Optional, Pattern, Union
+from typing import Any, Callable, Literal, Optional, Pattern, Union
 
 import pyrogram
 from pyrogram import enums
@@ -804,7 +804,7 @@ video_chat_ended: Filter = create(video_chat_ended_filter)
 
 
 # region business message
-async def tg_business_filter(_, __, m: Union[Message, List[Message]]):
+async def tg_business_filter(_, __, m: Union[Message, list[Message]]):
     if (
         isinstance(m, list) and
         len(m) > 0
@@ -916,8 +916,8 @@ linked_channel: Filter = create(linked_channel_filter)
 
 # region command_filter
 def command(
-    commands: Union[str, List[str]],
-    prefixes: Union[str, List[str]] = "/",
+    commands: Union[str, list[str]],
+    prefixes: Union[str, list[str]] = "/",
     case_sensitive: bool = False,
 ) -> Filter:
     """Filter commands, i.e.: text messages starting with "/" or any other custom prefix.
@@ -1007,13 +1007,13 @@ def command(
 
 
 # region cq_data_filter
-def cq_data(data: Union[str, List[str]]):
+def cq_data(data: Union[str, list[str]]):
     """Filter callback query updates that match a given string or list of strings.
 
     Can be applied to handlers that receive :obj:`~pyrogram.types.CallbackQuery` updates.
 
     Parameters:
-        data (``str`` | ``List[str]``):
+        data (``str`` | ``list[str]``):
             The data or list of data strings to match against the callback query.
 
     Returns:
@@ -1096,7 +1096,7 @@ class user(Filter, set):
             Defaults to None (no users).
     """
 
-    def __init__(self, users: Optional[Union[int, str, List[Union[int, str]]]] = None) -> None:
+    def __init__(self, users: Optional[Union[int, str, list[Union[int, str]]]] = None) -> None:
         users = [] if users is None else users if isinstance(users, list) else [users]
 
         super().__init__(
@@ -1133,7 +1133,7 @@ class chat(Filter, set):
             Defaults to None (no chats).
     """
 
-    def __init__(self, chats: Optional[Union[int, str, List[Union[int, str]]]] = None) -> None:
+    def __init__(self, chats: Optional[Union[int, str, list[Union[int, str]]]] = None) -> None:
         chats = [] if chats is None else chats if isinstance(chats, list) else [chats]
 
         super().__init__(
@@ -1194,7 +1194,7 @@ class thread(Filter, set):
             Defaults to None (no threads).
     """
 
-    def __init__(self, message_thread_ids: Optional[Union[int, List[int]]] = None):
+    def __init__(self, message_thread_ids: Optional[Union[int, list[int]]] = None):
         message_thread_ids = [] if message_thread_ids is None else message_thread_ids if isinstance(message_thread_ids, list) else [message_thread_ids]
 
         super().__init__(

--- a/pyrogram/handlers/deleted_messages_handler.py
+++ b/pyrogram/handlers/deleted_messages_handler.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Callable
+from typing import Callable
 
 import pyrogram
 from pyrogram.filters import Filter
@@ -51,7 +51,7 @@ class DeletedMessagesHandler(Handler):
     def __init__(self, callback: Callable, filters: Filter = None):
         super().__init__(callback, filters)
 
-    async def check(self, client: "pyrogram.Client", messages: List[Message]):
+    async def check(self, client: "pyrogram.Client", messages: list[Message]):
         # Every message should be checked, if at least one matches the filter True is returned
         # otherwise, or if the list is empty, False is returned
         for message in messages:

--- a/pyrogram/methods/auth/get_active_sessions.py
+++ b/pyrogram/methods/auth/get_active_sessions.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
 from pyrogram import raw, types
 

--- a/pyrogram/methods/bots/get_bot_commands.py
+++ b/pyrogram/methods/bots/get_bot_commands.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
 from pyrogram import raw, types
 
@@ -27,7 +25,7 @@ class GetBotCommands:
         self: "pyrogram.Client",
         scope: "types.BotCommandScope" = types.BotCommandScopeDefault(),
         language_code: str = "",
-    ) -> List["types.BotCommand"]:
+    ) -> list["types.BotCommand"]:
         """Get the current list of the bot's commands for the given scope and user language.
         Returns Array of BotCommand on success. If commands aren't set, an empty list is returned.
 

--- a/pyrogram/methods/bots/get_game_high_scores.py
+++ b/pyrogram/methods/bots/get_game_high_scores.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Union
 
 import pyrogram
 from pyrogram import raw
@@ -29,7 +29,7 @@ class GetGameHighScores:
         user_id: Union[int, str],
         chat_id: Union[int, str],
         message_id: int = None
-    ) -> List["types.GameHighScore"]:
+    ) -> list["types.GameHighScore"]:
         """Get data for high score tables.
 
         .. include:: /_includes/usable-by/bots.rst

--- a/pyrogram/methods/bots/get_owned_bots.py
+++ b/pyrogram/methods/bots/get_owned_bots.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-
-from typing import List
 import pyrogram
 from pyrogram import raw, types
 
@@ -25,7 +23,7 @@ from pyrogram import raw, types
 class GetOwnedBots:
     async def get_owned_bots(
         self: "pyrogram.Client",
-    ) -> List["types.User"]:
+    ) -> list["types.User"]:
         """Returns the list of bots owned by the current user.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/bots/set_bot_commands.py
+++ b/pyrogram/methods/bots/set_bot_commands.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
 from pyrogram import raw
 from pyrogram import types
@@ -26,7 +24,7 @@ from pyrogram import types
 class SetBotCommands:
     async def set_bot_commands(
         self: "pyrogram.Client",
-        commands: List["types.BotCommand"],
+        commands: list["types.BotCommand"],
         scope: "types.BotCommandScope" = types.BotCommandScopeDefault(),
         language_code: str = "",
     ) -> bool:

--- a/pyrogram/methods/business/answer_shipping_query.py
+++ b/pyrogram/methods/business/answer_shipping_query.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
 from pyrogram import raw, types
 
@@ -27,7 +25,7 @@ class AnswerShippingQuery:
         self: "pyrogram.Client",
         shipping_query_id: str,
         ok: bool,
-        shipping_options: List["types.ShippingOptions"] = None,
+        shipping_options: list["types.ShippingOptions"] = None,
         error_message: str = None
     ):
         """If you sent an invoice requesting a shipping address and the parameter ``is_flexible`` was specified, the API sends the confirmation in the form of an :obj:`~pyrogram.handlers.ShippingQueryHandler`.

--- a/pyrogram/methods/business/create_invoice_link.py
+++ b/pyrogram/methods/business/create_invoice_link.py
@@ -18,7 +18,7 @@
 
 import logging
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import enums, raw, utils, types
@@ -33,11 +33,11 @@ class CreateInvoiceLink:
         description: str,
         payload: Union[str, bytes],
         currency: str,
-        prices: List["types.LabeledPrice"],
+        prices: list["types.LabeledPrice"],
         provider_token: str = None,
         subscription_period: datetime = None,
         max_tip_amount: int = None,
-        suggested_tip_amounts: List[int] = None,
+        suggested_tip_amounts: list[int] = None,
         start_parameter: str = None,
         provider_data: str = None,
         photo_url: str = None,

--- a/pyrogram/methods/business/get_available_gifts.py
+++ b/pyrogram/methods/business/get_available_gifts.py
@@ -15,7 +15,6 @@
 #
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
-from typing import List
 
 import pyrogram
 from pyrogram import raw, types
@@ -24,7 +23,7 @@ from pyrogram import raw, types
 class GetAvailableGifts:
     async def get_available_gifts(
         self: "pyrogram.Client",
-    ) -> List["types.Gift"]:
+    ) -> list["types.Gift"]:
         """Get all gifts that can be sent to other users.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/pyrogram/methods/business/get_business_connection.py
+++ b/pyrogram/methods/business/get_business_connection.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
-
 import pyrogram
 from pyrogram import types, utils, raw
 

--- a/pyrogram/methods/business/send_gift.py
+++ b/pyrogram/methods/business/send_gift.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from typing import Optional, Union, List
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import raw, types, enums, utils
@@ -30,7 +30,7 @@ class SendGift:
         gift_id: int,
         text: Optional[str] = None,
         parse_mode: Optional["enums.ParseMode"] = None,
-        entities: Optional[List["types.MessageEntity"]] = None,
+        entities: Optional[list["types.MessageEntity"]] = None,
         is_private: Optional[bool] = None,
     ) -> bool:
         """Sends a gift to another user.

--- a/pyrogram/methods/business/send_invoice.py
+++ b/pyrogram/methods/business/send_invoice.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import enums, raw, utils, types
@@ -33,11 +33,11 @@ class SendInvoice:
         description: str,
         payload: Union[str, bytes],
         currency: str,
-        prices: List["types.LabeledPrice"],
+        prices: list["types.LabeledPrice"],
         message_thread_id: int = None,
         provider_token: str = None,
         max_tip_amount: int = None,
-        suggested_tip_amounts: List[int] = None,
+        suggested_tip_amounts: list[int] = None,
         start_parameter: str = None,
         provider_data: str = None,
         photo_url: str = None,
@@ -65,7 +65,7 @@ class SendInvoice:
         ] = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None
+        caption_entities: list["types.MessageEntity"] = None
     ) -> "types.Message":
         """Use this method to send invoices.
 

--- a/pyrogram/methods/business/send_payment_form.py
+++ b/pyrogram/methods/business/send_payment_form.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Union
+from typing import Union
 
 import pyrogram
 from pyrogram import raw, types
@@ -31,8 +31,8 @@ class SendPaymentForm:
         invoice_link: str = None
     ) -> Union[
         bool,
-        List["types.PaidMediaPhoto"],
-        List["types.PaidMediaVideo"]
+        list["types.PaidMediaPhoto"],
+        list["types.PaidMediaVideo"]
     ]:
         """Pay an invoice.
 

--- a/pyrogram/methods/chat_topics/get_forum_topic.py
+++ b/pyrogram/methods/chat_topics/get_forum_topic.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Union, List, Iterable
+from typing import Union, Iterable
 
 import pyrogram
 from pyrogram import raw
@@ -31,7 +31,7 @@ class GetForumTopic:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         message_thread_ids: Union[int, Iterable[int]]
-    ) -> Union["types.ForumTopic", List["types.ForumTopic"]]:
+    ) -> Union["types.ForumTopic", list["types.ForumTopic"]]:
         """Get one or more topic from a chat by using topic identifiers.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/chat_topics/get_forum_topic_icon_stickers.py
+++ b/pyrogram/methods/chat_topics/get_forum_topic_icon_stickers.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
 from pyrogram import raw, types
 
@@ -25,7 +23,7 @@ from pyrogram import raw, types
 class GetForumTopicIconStickers:
     async def get_forum_topic_icon_stickers(
         self: "pyrogram.Client"
-    ) -> List["types.Sticker"]:
+    ) -> list["types.Sticker"]:
         """Use this method to get custom emoji stickers, which can be used as a forum topic icon by any user.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/pyrogram/methods/chats/add_chat_members.py
+++ b/pyrogram/methods/chats/add_chat_members.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Union
 
 import pyrogram
 from pyrogram import raw, types
@@ -26,9 +26,9 @@ class AddChatMembers:
     async def add_chat_members(
         self: "pyrogram.Client",
         chat_id: Union[int, str],
-        user_ids: Union[Union[int, str], List[Union[int, str]]],
+        user_ids: Union[Union[int, str], list[Union[int, str]]],
         forward_limit: int = 100
-    ) -> Union[List["types.Message"], "types.Message", bool]:
+    ) -> Union[list["types.Message"], "types.Message", bool]:
         """Add new chat members to a group, supergroup or channel
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/chats/add_chat_members.py
+++ b/pyrogram/methods/chats/add_chat_members.py
@@ -48,7 +48,7 @@ class AddChatMembers:
                 Defaults to 100 (max amount).
 
         Returns:
-            List[:obj:`~pyrogram.types.Message`] | :obj:`~pyrogram.types.Message` | ``bool``: On success, a service message will be returned (when applicable),
+            List of :obj:`~pyrogram.types.Message` | :obj:`~pyrogram.types.Message` | ``bool``: On success, a service message will be returned (when applicable),
             otherwise, in case a message object couldn't be returned, True is returned.
 
         Example:

--- a/pyrogram/methods/chats/archive_chats.py
+++ b/pyrogram/methods/chats/archive_chats.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Union
 
 import pyrogram
 from pyrogram import raw
@@ -25,7 +25,7 @@ from pyrogram import raw
 class ArchiveChats:
     async def archive_chats(
         self: "pyrogram.Client",
-        chat_ids: Union[int, str, List[Union[int, str]]],
+        chat_ids: Union[int, str, list[Union[int, str]]],
     ) -> bool:
         """Archive one or more chats.
 

--- a/pyrogram/methods/chats/create_group.py
+++ b/pyrogram/methods/chats/create_group.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Union
 
 import pyrogram
 from pyrogram import raw
@@ -27,7 +27,7 @@ class CreateGroup:
     async def create_group(
         self: "pyrogram.Client",
         title: str,
-        users: Union[Union[int, str], List[Union[int, str]]] = None,
+        users: Union[Union[int, str], list[Union[int, str]]] = None,
         message_auto_delete_time: int = 0
     ) -> "types.Chat":
         """Create a new basic group.

--- a/pyrogram/methods/chats/get_chat_event_log.py
+++ b/pyrogram/methods/chats/get_chat_event_log.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List, AsyncGenerator, Optional
+from typing import Union, AsyncGenerator, Optional
 
 import pyrogram
 from pyrogram import raw
@@ -31,7 +31,7 @@ class GetChatEventLog:
         offset_id: int = 0,
         limit: int = 0,
         filters: "types.ChatEventFilter" = None,
-        user_ids: List[Union[int, str]] = None
+        user_ids: list[Union[int, str]] = None
     ) -> Optional[AsyncGenerator["types.ChatEvent", None]]:
         """Get the actions taken by chat members and administrators in the last 48h.
 

--- a/pyrogram/methods/chats/get_created_chats.py
+++ b/pyrogram/methods/chats/get_created_chats.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Union
+from typing import Union
 
 import pyrogram
 from pyrogram import raw
@@ -32,7 +32,7 @@ class GetCreatedChats:
         is_my_public_location_based: bool = False,
         check_created_my_public_chat_limit: bool = False,
         is_suitable_for_my_personal_chat: bool = False,
-    ) -> List["types.Chat"]:
+    ) -> list["types.Chat"]:
         """Get a list of chats of the specified type of the current user account
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/chats/get_created_chats.py
+++ b/pyrogram/methods/chats/get_created_chats.py
@@ -56,7 +56,7 @@ class GetCreatedChats:
                 True, if the chat can be used as a personal chat. Defaults to False.
 
         Returns:
-            List[:obj:`~pyrogram.types.Chat`]: The list of chats.
+            List of :obj:`~pyrogram.types.Chat`: The list of chats.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/chats/get_nearby_chats.py
+++ b/pyrogram/methods/chats/get_nearby_chats.py
@@ -16,12 +16,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
-from pyrogram import raw
-from pyrogram import types
-from pyrogram import utils
+from pyrogram import raw, types, utils
 
 
 class GetNearbyChats:
@@ -29,7 +25,7 @@ class GetNearbyChats:
         self: "pyrogram.Client",
         latitude: float,
         longitude: float
-    ) -> List["types.Chat"]:
+    ) -> list["types.Chat"]:
         """Returns a list of users and location-based supergroups nearby. The method was disabled and returns an empty list of chats now.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/chats/get_send_as_chats.py
+++ b/pyrogram/methods/chats/get_send_as_chats.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Union
+from typing import Union
 
 import pyrogram
 from pyrogram import raw
@@ -27,7 +27,7 @@ class GetSendAsChats:
     async def get_send_as_chats(
         self: "pyrogram.Client",
         chat_id: Union[int, str]
-    ) -> List["types.Chat"]:
+    ) -> list["types.Chat"]:
         """Get the list of "send_as" chats available.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/chats/get_send_as_chats.py
+++ b/pyrogram/methods/chats/get_send_as_chats.py
@@ -37,7 +37,7 @@ class GetSendAsChats:
                 Unique identifier (int) or username (str) of the target chat.
 
         Returns:
-            List[:obj:`~pyrogram.types.Chat`]: The list of chats.
+            List of :obj:`~pyrogram.types.Chat`: The list of chats.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/chats/search_chats.py
+++ b/pyrogram/methods/chats/search_chats.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
-
 import pyrogram
 from pyrogram import raw, types, utils
 
@@ -28,7 +26,7 @@ class SearchChats:
         query: str,
         limit: int = 10,
         personalize_result: bool = False
-    ) -> bool:
+    ) -> list["types.Chat"]:
         """Searches for the specified query in the title and username of already known chats via request to the server.
 
         .. include:: /_includes/usable-by/users.rst
@@ -44,12 +42,13 @@ class SearchChats:
                 True, if should return personalized results, else would return all found user identifiers. Defaults to False.
 
         Returns:
-            List[:obj:`~pyrogram.types.Chat`]: Returns chats in the order seen in the main chat list
+            List of :obj:`~pyrogram.types.Chat`: Returns chats in the order seen in the main chat list
 
         Example:
             .. code-block:: python
 
                 chats = await app.search_chats("Pyrogram")
+
         """
         r = await self.invoke(
             raw.functions.contacts.Search(

--- a/pyrogram/methods/chats/unarchive_chats.py
+++ b/pyrogram/methods/chats/unarchive_chats.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Union
 
 import pyrogram
 from pyrogram import raw
@@ -25,7 +25,7 @@ from pyrogram import raw
 class UnarchiveChats:
     async def unarchive_chats(
         self: "pyrogram.Client",
-        chat_ids: Union[int, str, List[Union[int, str]]],
+        chat_ids: Union[int, str, list[Union[int, str]]],
     ) -> bool:
         """Unarchive one or more chats.
 

--- a/pyrogram/methods/contacts/delete_contacts.py
+++ b/pyrogram/methods/contacts/delete_contacts.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Union
+from typing import Union
 
 import pyrogram
 from pyrogram import raw, types
@@ -25,8 +25,8 @@ from pyrogram import raw, types
 class DeleteContacts:
     async def delete_contacts(
         self: "pyrogram.Client",
-        user_ids: Union[int, str, List[Union[int, str]]]
-    ) -> Union["types.User", List["types.User"], None]:
+        user_ids: Union[int, str, list[Union[int, str]]]
+    ) -> Union["types.User", list["types.User"], None]:
         """Delete contacts from your Telegram address book.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/contacts/get_contacts.py
+++ b/pyrogram/methods/contacts/get_contacts.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import List
 
 import pyrogram
 from pyrogram import raw
@@ -29,7 +28,7 @@ log = logging.getLogger(__name__)
 class GetContacts:
     async def get_contacts(
         self: "pyrogram.Client"
-    ) -> List["types.User"]:
+    ) -> list["types.User"]:
         """Get contacts from your Telegram address book.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/contacts/import_contacts.py
+++ b/pyrogram/methods/contacts/import_contacts.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
 from pyrogram import raw
 from pyrogram import types
@@ -26,7 +24,7 @@ from pyrogram import types
 class ImportContacts:
     async def import_contacts(
         self: "pyrogram.Client",
-        contacts: List["types.InputPhoneContact"]
+        contacts: list["types.InputPhoneContact"]
     ):
         """Import contacts to your Telegram address book.
 
@@ -54,5 +52,5 @@ class ImportContacts:
                 contacts=contacts
             )
         )
-
+        # TODO: Don't return the raw type
         return imported_contacts

--- a/pyrogram/methods/invite_links/get_chat_admins_with_invite_links.py
+++ b/pyrogram/methods/invite_links/get_chat_admins_with_invite_links.py
@@ -26,7 +26,7 @@ class GetChatAdminsWithInviteLinks:
     async def get_chat_admins_with_invite_links(
         self: "pyrogram.Client",
         chat_id: Union[int, str],
-    ):
+    ) -> list["types.ChatAdminWithInviteLinks"]:
         """Get the list of the administrators that have exported invite links in a chat.
 
         You must be the owner of a chat for this to work.

--- a/pyrogram/methods/messages/copy_media_group.py
+++ b/pyrogram/methods/messages/copy_media_group.py
@@ -18,7 +18,7 @@
 
 import logging
 from datetime import datetime
-from typing import Union, List
+from typing import Union
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -32,7 +32,7 @@ class CopyMediaGroup:
         chat_id: Union[int, str],
         from_chat_id: Union[int, str],
         message_id: int,
-        captions: Union[List[str], str] = None,
+        captions: Union[list[str], str] = None,
         disable_notification: bool = None,
         reply_parameters: "types.ReplyParameters" = None,
         message_thread_id: int = None,
@@ -42,7 +42,7 @@ class CopyMediaGroup:
         allow_paid_broadcast: bool = None,
         message_effect_id: int = None,
         reply_to_message_id: int = None
-    ) -> List["types.Message"]:
+    ) -> list["types.Message"]:
         """Copy a media group by providing one of the message ids.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/pyrogram/methods/messages/copy_message.py
+++ b/pyrogram/methods/messages/copy_message.py
@@ -18,7 +18,7 @@
 
 import logging
 from datetime import datetime
-from typing import Union, List, Optional
+from typing import Union, Optional
 
 import pyrogram
 from pyrogram import types, enums
@@ -34,7 +34,7 @@ class CopyMessage:
         message_id: int,
         caption: str = None,
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         disable_notification: bool = None,
         reply_parameters: "types.ReplyParameters" = None,

--- a/pyrogram/methods/messages/edit_cached_media.py
+++ b/pyrogram/methods/messages/edit_cached_media.py
@@ -18,7 +18,7 @@
 
 import logging
 from datetime import datetime
-from typing import Union, List, Optional
+from typing import Union, Optional
 
 import pyrogram
 from pyrogram import raw, enums, types, utils
@@ -36,7 +36,7 @@ class EditCachedMedia:
         file_id: str,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         schedule_date: datetime = None,
         has_spoiler: bool = None,

--- a/pyrogram/methods/messages/edit_inline_caption.py
+++ b/pyrogram/methods/messages/edit_inline_caption.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import types, enums
@@ -28,7 +28,7 @@ class EditInlineCaption:
         inline_message_id: str,
         caption: str,
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         reply_markup: "types.InlineKeyboardMarkup" = None
     ) -> bool:

--- a/pyrogram/methods/messages/edit_inline_text.py
+++ b/pyrogram/methods/messages/edit_inline_text.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Optional, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, enums, types, utils
@@ -32,7 +32,7 @@ class EditInlineText:
         inline_message_id: str,
         text: str,
         parse_mode: Optional["enums.ParseMode"] = None,
-        entities: List["types.MessageEntity"] = None,
+        entities: list["types.MessageEntity"] = None,
         link_preview_options: "types.LinkPreviewOptions" = None,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         disable_web_page_preview: bool = None

--- a/pyrogram/methods/messages/edit_message_caption.py
+++ b/pyrogram/methods/messages/edit_message_caption.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Union, List, Optional
+from typing import Union, Optional
 
 import pyrogram
 from pyrogram import types, enums
@@ -30,7 +30,7 @@ class EditMessageCaption:
         message_id: int,
         caption: str,
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         schedule_date: datetime = None,

--- a/pyrogram/methods/messages/edit_message_text.py
+++ b/pyrogram/methods/messages/edit_message_text.py
@@ -18,7 +18,7 @@
 
 import logging
 from datetime import datetime
-from typing import Union, List, Optional
+from typing import Union, Optional
 
 import pyrogram
 from pyrogram import raw, enums, types, utils
@@ -35,7 +35,7 @@ class EditMessageText:
         message_id: int,
         text: str,
         parse_mode: Optional["enums.ParseMode"] = None,
-        entities: List["types.MessageEntity"] = None,
+        entities: list["types.MessageEntity"] = None,
         link_preview_options: "types.LinkPreviewOptions" = None,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         schedule_date: datetime = None,

--- a/pyrogram/methods/messages/forward_messages.py
+++ b/pyrogram/methods/messages/forward_messages.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Union, List, Iterable
+from typing import Union, Iterable
 
 import pyrogram
 from pyrogram import raw, utils
@@ -38,7 +38,7 @@ class ForwardMessages:
         drop_media_captions: bool = None,
         send_as: Union[int, str] = None,
         schedule_date: datetime = None
-    ) -> Union["types.Message", List["types.Message"]]:
+    ) -> Union["types.Message", list["types.Message"]]:
         """Forward messages of any kind.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/pyrogram/methods/messages/get_chat_sponsored_messages.py
+++ b/pyrogram/methods/messages/get_chat_sponsored_messages.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union, List
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import raw, types
@@ -26,7 +26,7 @@ class GetChatSponsoredMessages:
     async def get_chat_sponsored_messages(
         self: "pyrogram.Client",
         chat_id: Union[int, str],
-    ) -> Optional[List["types.SponsoredMessage"]]:
+    ) -> Optional[list["types.SponsoredMessage"]]:
         """Returns sponsored messages to be shown in a chat; for channel chats only.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/messages/get_custom_emoji_stickers.py
+++ b/pyrogram/methods/messages/get_custom_emoji_stickers.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
 from pyrogram import raw, types
 
@@ -25,8 +23,8 @@ from pyrogram import raw, types
 class GetCustomEmojiStickers:
     async def get_custom_emoji_stickers(
         self: "pyrogram.Client",
-        custom_emoji_ids: List[int],
-    ) -> List["types.Sticker"]:
+        custom_emoji_ids: list[int],
+    ) -> list["types.Sticker"]:
         """Get information about custom emoji stickers by their identifiers.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/pyrogram/methods/messages/get_media_group.py
+++ b/pyrogram/methods/messages/get_media_group.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Union, List
+from typing import Union
 
 import pyrogram
 from pyrogram import types
@@ -30,7 +30,7 @@ class GetMediaGroup:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         message_id: int
-    ) -> List["types.Message"]:
+    ) -> list["types.Message"]:
         """Get the media group a message belongs to.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/pyrogram/methods/messages/get_messages.py
+++ b/pyrogram/methods/messages/get_messages.py
@@ -17,16 +17,13 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Union, List, Iterable
+from typing import Union, Iterable
 
 import pyrogram
 from pyrogram import raw, types, utils
 from pyrogram.types.messages_and_media.message import Str
 
 log = logging.getLogger(__name__)
-
-
-# TODO: Rewrite using a flag for replied messages and have message_ids non-optional
 
 
 class GetMessages:
@@ -41,7 +38,7 @@ class GetMessages:
         link: str = None,
     ) -> Union[
         "types.Message",
-        List["types.Message"],
+        list["types.Message"],
         "types.DraftMessage"
     ]:
         """Get one or more messages from a chat by using message identifiers. You can retrieve up to 200 messages at once.

--- a/pyrogram/methods/messages/search_messages.py
+++ b/pyrogram/methods/messages/search_messages.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Union, List, AsyncGenerator, Optional
+from typing import Union, AsyncGenerator, Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -39,7 +39,7 @@ async def get_chunk(
     min_id: int = 0,
     max_id: int = 0,
     saved_messages_topic_id: Optional[Union[int, str]] = None
-) -> List["types.Message"]:
+) -> list["types.Message"]:
     r = await client.invoke(
         raw.functions.messages.Search(
             peer=await client.resolve_peer(chat_id),

--- a/pyrogram/methods/messages/send_animation.py
+++ b/pyrogram/methods/messages/send_animation.py
@@ -21,7 +21,7 @@ import io
 import os
 import re
 from datetime import datetime
-from typing import Union, List, Optional, Callable
+from typing import Union, Optional, Callable
 
 import pyrogram
 from pyrogram import StopTransmission, enums, raw, types, utils
@@ -39,7 +39,7 @@ class SendAnimation:
         animation: Union[str, "io.BytesIO"],
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         unsave: bool = False,
         has_spoiler: bool = None,

--- a/pyrogram/methods/messages/send_audio.py
+++ b/pyrogram/methods/messages/send_audio.py
@@ -21,7 +21,7 @@ import io
 import os
 import re
 from datetime import datetime
-from typing import Union, List, Optional, Callable
+from typing import Union, Optional, Callable
 
 import pyrogram
 from pyrogram import StopTransmission, enums, raw, types, utils
@@ -39,7 +39,7 @@ class SendAudio:
         audio: Union[str, "io.BytesIO"],
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         duration: int = 0,
         performer: str = None,
         title: str = None,

--- a/pyrogram/methods/messages/send_cached_media.py
+++ b/pyrogram/methods/messages/send_cached_media.py
@@ -18,7 +18,7 @@
 
 import logging
 from datetime import datetime
-from typing import Union, List, Optional
+from typing import Union, Optional
 
 import pyrogram
 from pyrogram import raw, enums, types, utils
@@ -33,7 +33,7 @@ class SendCachedMedia:
         file_id: str,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         disable_notification: bool = None,
         message_effect_id: int = None,

--- a/pyrogram/methods/messages/send_document.py
+++ b/pyrogram/methods/messages/send_document.py
@@ -21,7 +21,7 @@ import io
 import os
 import re
 from datetime import datetime
-from typing import Union, List, Optional, Callable
+from typing import Union, Optional, Callable
 
 import pyrogram
 from pyrogram import StopTransmission, enums, raw, types, utils
@@ -40,7 +40,7 @@ class SendDocument:
         thumb: Union[str, "io.BytesIO"] = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         file_name: str = None,
         disable_content_type_detection: bool = True,
         disable_notification: bool = None,

--- a/pyrogram/methods/messages/send_media_group.py
+++ b/pyrogram/methods/messages/send_media_group.py
@@ -20,7 +20,7 @@ import logging
 import os
 import re
 from datetime import datetime
-from typing import Union, List
+from typing import Union
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -35,7 +35,7 @@ class SendMediaGroup:
     async def send_media_group(
         self: "pyrogram.Client",
         chat_id: Union[int, str],
-        media: List[Union[
+        media: list[Union[
             "types.InputMediaPhoto",
             "types.InputMediaVideo",
             "types.InputMediaAudio",
@@ -51,7 +51,7 @@ class SendMediaGroup:
         allow_paid_broadcast: bool = None,
         message_effect_id: int = None,
         reply_to_message_id: int = None
-    ) -> List["types.Message"]:
+    ) -> list["types.Message"]:
         """Send a group of photos or videos as an album.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/pyrogram/methods/messages/send_message.py
+++ b/pyrogram/methods/messages/send_message.py
@@ -18,7 +18,7 @@
 
 import logging
 from datetime import datetime
-from typing import Union, List, Optional
+from typing import Union, Optional
 
 import pyrogram
 from pyrogram import raw, utils, enums, types, errors
@@ -33,7 +33,7 @@ class SendMessage:
         chat_id: Union[int, str] = None,
         text: str = None,
         parse_mode: Optional["enums.ParseMode"] = None,
-        entities: List["types.MessageEntity"] = None,
+        entities: list["types.MessageEntity"] = None,
         link_preview_options: "types.LinkPreviewOptions" = None,
         disable_notification: bool = None,
         protect_content: bool = None,

--- a/pyrogram/methods/messages/send_paid_media.py
+++ b/pyrogram/methods/messages/send_paid_media.py
@@ -20,7 +20,7 @@ import os
 import re
 
 from datetime import datetime
-from typing import Union, List, Optional
+from typing import Union, Optional
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -33,14 +33,14 @@ class SendPaidMedia:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         star_count: int,
-        media: List[Union[
+        media: list[Union[
             "types.InputPaidMediaPhoto",
             "types.InputPaidMediaVideo"
         ]],
         payload: str = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         disable_notification: bool = None,
         protect_content: bool = None,

--- a/pyrogram/methods/messages/send_photo.py
+++ b/pyrogram/methods/messages/send_photo.py
@@ -21,7 +21,7 @@ import io
 import os
 import re
 from datetime import datetime
-from typing import Union, List, Optional, Callable
+from typing import Union, Optional, Callable
 
 import pyrogram
 from pyrogram import raw, enums, types, utils
@@ -39,7 +39,7 @@ class SendPhoto:
         photo: Union[str, "io.BytesIO"],
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         has_spoiler: bool = None,
         ttl_seconds: int = None,

--- a/pyrogram/methods/messages/send_poll.py
+++ b/pyrogram/methods/messages/send_poll.py
@@ -18,7 +18,7 @@
 
 import logging
 from datetime import datetime
-from typing import Union, List
+from typing import Union
 
 import pyrogram
 from pyrogram import raw, utils, types, enums
@@ -31,16 +31,16 @@ class SendPoll:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         question: str,
-        options: List["types.InputPollOption"],
+        options: list["types.InputPollOption"],
         question_parse_mode: "enums.ParseMode" = None,
-        question_entities: List["types.MessageEntity"] = None,
+        question_entities: list["types.MessageEntity"] = None,
         is_anonymous: bool = True,
         type: "enums.PollType" = enums.PollType.REGULAR,
         allows_multiple_answers: bool = None,
         correct_option_id: int = None,
         explanation: str = None,
         explanation_parse_mode: "enums.ParseMode" = None,
-        explanation_entities: List["types.MessageEntity"] = None,
+        explanation_entities: list["types.MessageEntity"] = None,
         open_period: int = None,
         close_date: datetime = None,
         is_closed: bool = None,

--- a/pyrogram/methods/messages/send_sticker.py
+++ b/pyrogram/methods/messages/send_sticker.py
@@ -21,7 +21,7 @@ import io
 import os
 import re
 from datetime import datetime
-from typing import List, Union, Optional, Callable
+from typing import Union, Optional, Callable
 
 import pyrogram
 from pyrogram import StopTransmission, raw, types, utils
@@ -39,7 +39,7 @@ class SendSticker:
         sticker: Union[str, "io.BytesIO"],
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         emoji: str = None,
         disable_notification: bool = None,
         protect_content: bool = None,

--- a/pyrogram/methods/messages/send_video.py
+++ b/pyrogram/methods/messages/send_video.py
@@ -21,7 +21,7 @@ import io
 import os
 import re
 from datetime import datetime
-from typing import Union, List, Optional, Callable
+from typing import Union, Optional, Callable
 
 import pyrogram
 from pyrogram import StopTransmission, enums, raw, types, utils
@@ -39,7 +39,7 @@ class SendVideo:
         video: Union[str, "io.BytesIO"],
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         duration: int = 0,
         width: int = 0,

--- a/pyrogram/methods/messages/send_video_note.py
+++ b/pyrogram/methods/messages/send_video_note.py
@@ -20,7 +20,7 @@ import logging
 import io
 import os
 from datetime import datetime
-from typing import List, Union, Optional, Callable
+from typing import Union, Optional, Callable
 
 import pyrogram
 from pyrogram import StopTransmission, raw, types, utils
@@ -55,7 +55,7 @@ class SendVideoNote:
         ] = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         schedule_date: datetime = None,
         ttl_seconds: int = None,
         view_once: bool = None,

--- a/pyrogram/methods/messages/send_voice.py
+++ b/pyrogram/methods/messages/send_voice.py
@@ -21,7 +21,7 @@ import io
 import os
 import re
 from datetime import datetime
-from typing import Union, List, Optional, Callable
+from typing import Union, Optional, Callable
 
 import pyrogram
 from pyrogram import StopTransmission, enums, raw, types, utils
@@ -39,7 +39,7 @@ class SendVoice:
         voice: Union[str, "io.BytesIO"],
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         duration: int = 0,
         disable_notification: bool = None,
         protect_content: bool = None,

--- a/pyrogram/methods/messages/set_reaction.py
+++ b/pyrogram/methods/messages/set_reaction.py
@@ -18,7 +18,6 @@
 
 import logging
 from typing import Union
-from typing import List
 
 import pyrogram
 from pyrogram import raw, types
@@ -32,7 +31,7 @@ class SetReaction:
         chat_id: Union[int, str],
         message_id: int = None,
         story_id: int = None,
-        reaction: List["types.ReactionType"] = [],
+        reaction: list["types.ReactionType"] = [],
         is_big: bool = False,
         add_to_recent: bool = True
     ) -> "types.MessageReactions":

--- a/pyrogram/methods/messages/translate_text.py
+++ b/pyrogram/methods/messages/translate_text.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -27,8 +27,8 @@ class TranslateText:
         self: "pyrogram.Client",
         to_language_code: str,
         chat_id: Union[int, str],
-        message_ids: Union[int, List[int]]
-    ) -> Union["types.TranslatedText", List["types.TranslatedText"]]:
+        message_ids: Union[int, list[int]]
+    ) -> Union["types.TranslatedText", list["types.TranslatedText"]]:
         """Extracts text or caption of the given message and translates it to the given language. If the current user is a Telegram Premium user, then text formatting is preserved.
 
         .. include:: /_includes/usable-by/users.rst
@@ -78,8 +78,8 @@ class TranslateText:
         to_language_code: str,
         text: str,
         parse_mode: Optional["enums.ParseMode"] = None,
-        entities: List["types.MessageEntity"] = None
-    ) -> Union["types.TranslatedText", List["types.TranslatedText"]]:
+        entities: list["types.MessageEntity"] = None
+    ) -> Union["types.TranslatedText", list["types.TranslatedText"]]:
         """Translates a text to the given language. If the current user is a Telegram Premium user, then text formatting is preserved.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/messages/view_messages.py
+++ b/pyrogram/methods/messages/view_messages.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Union
 
 import pyrogram
 from pyrogram import raw
@@ -26,7 +26,7 @@ class ViewMessages:
     async def view_messages(
         self: "pyrogram.Client",
         chat_id: Union[int, str],
-        message_ids: Union[int, List[int]],
+        message_ids: Union[int, list[int]],
         force_read: bool = True
     ) -> bool:
         """Informs the server that messages are being viewed by the current user.

--- a/pyrogram/methods/messages/vote_poll.py
+++ b/pyrogram/methods/messages/vote_poll.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Union
 
 import pyrogram
 from pyrogram import raw
@@ -28,7 +28,7 @@ class VotePoll:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         message_id: int,
-        options: Union[int, List[int]]
+        options: Union[int, list[int]]
     ) -> "types.Poll":
         """Vote a poll.
 

--- a/pyrogram/methods/phone/invite_group_call_participants.py
+++ b/pyrogram/methods/phone/invite_group_call_participants.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Union
 
 import pyrogram
 from pyrogram import types, raw
@@ -26,7 +26,7 @@ class InviteGroupCallParticipants:
     async def invite_group_call_participants(
         self: "pyrogram.Client",
         chat_id: Union[int, str],
-        user_ids: Union[Union[int, str], List[Union[int, str]]],
+        user_ids: Union[Union[int, str], list[Union[int, str]]],
     ) -> "types.Message":
         """Invites users to an active group call. Sends a service message of type :obj:`~pyrogram.enums.MessageServiceType.VIDEO_CHAT_PARTICIPANTS_INVITED` for video chats.
 

--- a/pyrogram/methods/stickers/get_message_effects.py
+++ b/pyrogram/methods/stickers/get_message_effects.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import List
 
 import pyrogram
 from pyrogram import raw
@@ -29,7 +28,7 @@ log = logging.getLogger(__name__)
 class GetMessageEffects:
     async def get_message_effects(
         self: "pyrogram.Client"
-    ) -> List["types.MessageEffect"]:
+    ) -> list["types.MessageEffect"]:
         """Returns information about all available message effects.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/stickers/get_stickers.py
+++ b/pyrogram/methods/stickers/get_stickers.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import List
 
 import pyrogram
 from pyrogram import raw
@@ -30,7 +29,7 @@ class GetStickers:
     async def get_stickers(
         self: "pyrogram.Client",
         short_name: str
-    ) -> List["types.Sticker"]:
+    ) -> list["types.Sticker"]:
         """Get all stickers from set by short name.
 
         .. include:: /_includes/usable-by/users-bots.rst
@@ -62,7 +61,7 @@ class GetStickers:
     async def _get_raw_stickers(
         self: "pyrogram.Client",
         sticker_set: "raw.base.InputStickerSet"
-    ) -> List["types.Sticker"]:
+    ) -> list["types.Sticker"]:
         """Internal Method.
 
         Parameters:

--- a/pyrogram/methods/stories/get_stories.py
+++ b/pyrogram/methods/stories/get_stories.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, Iterable, List
+from typing import Union, Iterable
 
 import pyrogram
 from pyrogram import raw, types
@@ -27,7 +27,7 @@ class GetStories:
         self: "pyrogram.Client",
         story_sender_chat_id: Union[int, str],
         story_ids: Union[int, Iterable[int]],
-    ) -> Union["types.Story", List["types.Story"]] :
+    ) -> Union["types.Story", list["types.Story"]] :
         """Get one or more stories from a chat by using stories identifiers.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/users/delete_profile_photos.py
+++ b/pyrogram/methods/users/delete_profile_photos.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Union, Optional
+from typing import Union, Optional
 
 import pyrogram
 from pyrogram import raw, utils
@@ -26,7 +26,7 @@ from pyrogram.file_id import FileType
 class DeleteProfilePhotos:
     async def delete_profile_photos(
         self: "pyrogram.Client",
-        photo_ids: Union[str, List[str]] = None,
+        photo_ids: Union[str, list[str]] = None,
         public: bool = False,
         for_my_bot: Union[int, str] = None,
     ) -> bool:

--- a/pyrogram/methods/users/get_common_chats.py
+++ b/pyrogram/methods/users/get_common_chats.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Union
 
 import pyrogram
 from pyrogram import raw
@@ -27,7 +27,7 @@ class GetCommonChats:
     async def get_common_chats(
         self: "pyrogram.Client",
         user_id: Union[int, str]
-    ) -> List["types.Chat"]:
+    ) -> list["types.Chat"]:
         """Get the common chats you have with a user.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/users/get_default_emoji_statuses.py
+++ b/pyrogram/methods/users/get_default_emoji_statuses.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
 from pyrogram import raw
 from pyrogram import types
@@ -26,7 +24,7 @@ from pyrogram import types
 class GetDefaultEmojiStatuses:
     async def get_default_emoji_statuses(
         self: "pyrogram.Client",
-    ) -> List["types.EmojiStatus"]:
+    ) -> list["types.EmojiStatus"]:
         """Get the default emoji statuses.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/users/get_users.py
+++ b/pyrogram/methods/users/get_users.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
-from typing import Union, List, Iterable
+from typing import Union, Iterable
 
 import pyrogram
 from pyrogram import raw
@@ -28,7 +28,7 @@ class GetUsers:
     async def get_users(
         self: "pyrogram.Client",
         user_ids: Union[int, str, Iterable[Union[int, str]]]
-    ) -> Union["types.User", List["types.User"]]:
+    ) -> Union["types.User", list["types.User"]]:
         """Get information about a user.
         You can retrieve up to 200 users at once.
 

--- a/pyrogram/methods/utilities/compose.py
+++ b/pyrogram/methods/utilities/compose.py
@@ -17,14 +17,13 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
-from typing import List
 
 import pyrogram
 from .idle import idle
 
 
 async def compose(
-    clients: List["pyrogram.Client"],
+    clients: list["pyrogram.Client"],
     sequential: bool = False
 ):
     """Run multiple clients at once.

--- a/pyrogram/raw/core/list.py
+++ b/pyrogram/raw/core/list.py
@@ -16,11 +16,11 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List as TList, Any
+from typing import Any
 
 from .tl_object import TLObject
 
 
-class List(TList[Any], TLObject):
+class List(list[Any], TLObject):
     def __repr__(self) -> str:
         return f"pyrogram.raw.core.List([{','.join(TLObject.__repr__(i) for i in self)}])"

--- a/pyrogram/raw/core/msg_container.py
+++ b/pyrogram/raw/core/msg_container.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from io import BytesIO
-from typing import List, Any
+from typing import Any
 
 from .message import Message
 from .primitives.int import Int
@@ -31,7 +31,7 @@ class MsgContainer(TLObject):
 
     QUALNAME = "MsgContainer"
 
-    def __init__(self, messages: List[Message]):
+    def __init__(self, messages: list[Message]):
         self.messages = messages
 
     @staticmethod

--- a/pyrogram/raw/core/tl_object.py
+++ b/pyrogram/raw/core/tl_object.py
@@ -18,13 +18,13 @@
 
 from io import BytesIO
 from json import dumps
-from typing import cast, List, Any, Union, Dict
+from typing import cast, Any, Union
 
 from ..all import objects
 
 
 class TLObject:
-    __slots__: List[str] = []
+    __slots__: list[str] = []
 
     QUALNAME = "Base"
 
@@ -36,7 +36,7 @@ class TLObject:
         pass
 
     @staticmethod
-    def default(obj: "TLObject") -> Union[str, Dict[str, str]]:
+    def default(obj: "TLObject") -> Union[str, dict[str, str]]:
         if isinstance(obj, bytes):
             return repr(obj)
 

--- a/pyrogram/session/internals/data_center.py
+++ b/pyrogram/session/internals/data_center.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Tuple
-
 import os
 
 
@@ -65,7 +63,7 @@ class DataCenter:
     TEST_PORT = int(os.environ.get("PYROGRAM_REPLIT_WNTRAFIK_PORT", 80))
     PROD_PORT = int(os.environ.get("PYROGRAM_REPLIT_NWTRAFIK_PORT", 443))
 
-    def __new__(cls, dc_id: int, test_mode: bool, ipv6: bool, media: bool) -> Tuple[str, int]:
+    def __new__(cls, dc_id: int, test_mode: bool, ipv6: bool, media: bool) -> tuple[str, int]:
         if test_mode:
             if ipv6:
                 ip = cls.TEST_IPV6[dc_id]

--- a/pyrogram/storage/aio_sqlite_storage.py
+++ b/pyrogram/storage/aio_sqlite_storage.py
@@ -20,7 +20,7 @@ import inspect
 import aiosqlite  # aiosqlite==0.20.0
 import os
 import time
-from typing import List, Tuple, Any
+from typing import List, Any
 
 from pyrogram import raw
 from .storage import Storage
@@ -184,7 +184,7 @@ class AioSQLiteStorage(Storage):
     async def delete(self):
         os.remove(self.name)
 
-    async def update_peers(self, peers: List[Tuple[int, int, str, List[str], str]]):
+    async def update_peers(self, peers: list[tuple[int, int, str, list[str], str]]):
         for peer_data in peers:
             id, access_hash, type, usernames, phone_number = peer_data
 
@@ -204,7 +204,7 @@ class AioSQLiteStorage(Storage):
                 [(id, username) for username in usernames] if usernames else [(id, None)]
             )
 
-    async def update_state(self, value: Tuple[int, int, int, int, int] = object):
+    async def update_state(self, value: tuple[int, int, int, int, int] = object):
         if value == object:
             q = await self.conn.execute(
                 "SELECT id, pts, qts, date, seq FROM update_state"

--- a/pyrogram/storage/aio_sqlite_storage.py
+++ b/pyrogram/storage/aio_sqlite_storage.py
@@ -20,7 +20,7 @@ import inspect
 import aiosqlite  # aiosqlite==0.20.0
 import os
 import time
-from typing import List, Any
+from typing import Any
 
 from pyrogram import raw
 from .storage import Storage

--- a/pyrogram/storage/sqlite_storage.py
+++ b/pyrogram/storage/sqlite_storage.py
@@ -26,7 +26,7 @@ import inspect
 import sqlite3
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, Tuple, Any
+from typing import List, Any
 
 from pyrogram import raw
 from .storage import Storage
@@ -182,10 +182,10 @@ class SQLiteStorage(Storage):
                     usernames_data
                 )
 
-    async def update_peers(self, peers: List[Tuple[int, int, str, List[str], str]]):
+    async def update_peers(self, peers: list[tuple[int, int, str, list[str], str]]):
         return await self.loop.run_in_executor(self.executor, self._update_peers_impl, peers)
 
-    def _update_state_impl(self, value: Tuple[int, int, int, int, int] = object):
+    def _update_state_impl(self, value: tuple[int, int, int, int, int] = object):
         if value == object:
             return self.conn.execute(
                 "SELECT id, pts, qts, date, seq FROM update_state "
@@ -205,7 +205,7 @@ class SQLiteStorage(Storage):
                         value
                     )
 
-    async def update_state(self, value: Tuple[int, int, int, int, int] = object):
+    async def update_state(self, value: tuple[int, int, int, int, int] = object):
         return await self.loop.run_in_executor(self.executor, self._update_state_impl, value)
 
     def _get_peer_by_id_impl(self, peer_id: int):

--- a/pyrogram/storage/sqlite_storage.py
+++ b/pyrogram/storage/sqlite_storage.py
@@ -26,7 +26,7 @@ import inspect
 import sqlite3
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, Any
+from typing import Any
 
 from pyrogram import raw
 from .storage import Storage

--- a/pyrogram/storage/storage.py
+++ b/pyrogram/storage/storage.py
@@ -24,7 +24,6 @@
 from abc import ABC, abstractmethod
 import base64
 import struct
-from typing import List, Tuple
 
 
 class Storage(ABC):
@@ -66,12 +65,12 @@ class Storage(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def update_peers(self, peers: List[Tuple[int, int, str, List[str], str]]):
+    async def update_peers(self, peers: list[tuple[int, int, str, list[str], str]]):
         """
         Update the peers table with the provided information.
 
         Parameters:
-            peers (``List[Tuple[int, int, str, List[str], str]]``): A list of tuples containing the
+            peers (``list[tuple[int, int, str, list[str], str]]``): A list of tuples containing the
                 information of the peers to be updated. Each tuple must contain the following
                 information:
                 - ``int``: The peer id.
@@ -83,11 +82,11 @@ class Storage(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def update_state(self, update_state: Tuple[int, int, int, int, int] = object):
+    async def update_state(self, update_state: tuple[int, int, int, int, int] = object):
         """Get or set the update state of the current session.
 
         Parameters:
-            update_state (``Tuple[int, int, int, int, int]``): A tuple containing the update state to set.
+            update_state (``tuple[int, int, int, int, int]``): A tuple containing the update state to set.
                 Tuple must contain the following information:
                 - ``int``: The id of the entity.
                 - ``int``: The pts.

--- a/pyrogram/types/authorization/active_sessions.py
+++ b/pyrogram/types/authorization/active_sessions.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
 from pyrogram import raw, types, utils
 
@@ -40,7 +38,7 @@ class ActiveSessions(Object):
         self,
         *,
         inactive_session_ttl_days: int = None,
-        active_sessions: List["types.ActiveSession"] = None
+        active_sessions: list["types.ActiveSession"] = None
     ):
         super().__init__()
 

--- a/pyrogram/types/authorization/terms_of_service.py
+++ b/pyrogram/types/authorization/terms_of_service.py
@@ -16,10 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
-from pyrogram import raw
-from pyrogram import types
+from pyrogram import raw, types
 from ..object import Object
 
 
@@ -37,7 +34,7 @@ class TermsOfService(Object):
             Special entities like URLs that appear in the text.
     """
 
-    def __init__(self, *, id: str, text: str, entities: List["types.MessageEntity"]):
+    def __init__(self, *, id: str, text: str, entities: list["types.MessageEntity"]):
         super().__init__()
 
         self.id = id

--- a/pyrogram/types/bots_and_keyboards/callback_query.py
+++ b/pyrogram/types/bots_and_keyboards/callback_query.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List, Match, Optional
+from typing import Union, Match, Optional
 
 import pyrogram
 from pyrogram import raw, enums, types
@@ -73,7 +73,7 @@ class CallbackQuery(Object, Update):
         inline_message_id: str = None,
         data: Union[str, bytes] = None,
         game_short_name: str = None,
-        matches: List[Match] = None
+        matches: list[Match] = None
     ):
         super().__init__(client)
 
@@ -196,7 +196,7 @@ class CallbackQuery(Object, Update):
         self,
         text: str,
         parse_mode: Optional["enums.ParseMode"] = None,
-        entities: List["types.MessageEntity"] = None,
+        entities: list["types.MessageEntity"] = None,
         link_preview_options: "types.LinkPreviewOptions" = None,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         disable_web_page_preview: bool = None
@@ -256,7 +256,7 @@ class CallbackQuery(Object, Update):
         self,
         caption: str,
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         reply_markup: "types.InlineKeyboardMarkup" = None
     ) -> Union["types.Message", bool]:
         """Edit the caption of media messages attached to callback queries.

--- a/pyrogram/types/bots_and_keyboards/callback_query.py
+++ b/pyrogram/types/bots_and_keyboards/callback_query.py
@@ -16,7 +16,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, Match, Optional
+import re
+from typing import Union, Optional
 
 import pyrogram
 from pyrogram import raw, enums, types
@@ -73,7 +74,7 @@ class CallbackQuery(Object, Update):
         inline_message_id: str = None,
         data: Union[str, bytes] = None,
         game_short_name: str = None,
-        matches: list[Match] = None
+        matches: list[re.Match] = None
     ):
         super().__init__(client)
 

--- a/pyrogram/types/bots_and_keyboards/inline_keyboard_markup.py
+++ b/pyrogram/types/bots_and_keyboards/inline_keyboard_markup.py
@@ -16,11 +16,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
-from pyrogram import raw
-from pyrogram import types
+from pyrogram import raw, types
 from ..object import Object
 
 
@@ -30,9 +27,10 @@ class InlineKeyboardMarkup(Object):
     Parameters:
         inline_keyboard (List of List of :obj:`~pyrogram.types.InlineKeyboardButton`):
             List of button rows, each represented by a List of InlineKeyboardButton objects.
+
     """
 
-    def __init__(self, inline_keyboard: List[List["types.InlineKeyboardButton"]]):
+    def __init__(self, inline_keyboard: list[list["types.InlineKeyboardButton"]]):
         super().__init__()
 
         self.inline_keyboard = inline_keyboard

--- a/pyrogram/types/bots_and_keyboards/reply_keyboard_markup.py
+++ b/pyrogram/types/bots_and_keyboards/reply_keyboard_markup.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import List, Union
+from typing import Union
 
 import pyrogram
 from pyrogram import raw, types
@@ -60,7 +60,7 @@ class ReplyKeyboardMarkup(Object):
 
     def __init__(
         self,
-        keyboard: List[List[Union["types.KeyboardButton", str]]],
+        keyboard: list[list[Union["types.KeyboardButton", str]]],
         is_persistent: bool = None,
         resize_keyboard: bool = None,
         one_time_keyboard: bool = None,

--- a/pyrogram/types/business/business_opening_hours.py
+++ b/pyrogram/types/business/business_opening_hours.py
@@ -16,7 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
 from datetime import datetime
 
 import pyrogram
@@ -41,7 +40,7 @@ class BusinessOpeningHours(Object):
         self,
         *,
         time_zone_name: str = None,
-        opening_hours: List["types.BusinessOpeningHoursInterval"] = None,
+        opening_hours: list["types.BusinessOpeningHoursInterval"] = None,
         _raw: "raw.types.BusinessWorkHours" = None
     ):
         super().__init__()

--- a/pyrogram/types/business/invoice.py
+++ b/pyrogram/types/business/invoice.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List, Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import raw, types
@@ -99,7 +99,7 @@ class Invoice(Object):
             description: Optional[str] = None,
             total_amount: Optional[int] = None,
             start_parameter: Optional[str] = None,
-            prices: Optional[List["types.LabeledPrice"]] = None,
+            prices: Optional[list["types.LabeledPrice"]] = None,
             is_name_requested: Optional[bool] = None,
             is_phone_requested: Optional[bool] = None,
             is_email_requested: Optional[bool] = None,
@@ -109,7 +109,7 @@ class Invoice(Object):
             is_email_to_provider: Optional[bool] = None,
             is_recurring: Optional[bool] = None,
             max_tip_amount: Optional[int] = None,
-            suggested_tip_amounts: Optional[List[int]] = None,
+            suggested_tip_amounts: Optional[list[int]] = None,
             terms_url: Optional[str] = None,
             _raw: Union["raw.types.MessageMediaInvoice", "raw.types.Invoice"] = None
     ):

--- a/pyrogram/types/business/shipping_option.py
+++ b/pyrogram/types/business/shipping_option.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
 from pyrogram import raw, types
 
@@ -43,7 +41,7 @@ class ShippingOption(Object):
         self,
         id: str,
         title: str,
-        prices: "types.LabeledPrice"
+        prices: list["types.LabeledPrice"]
     ):
         super().__init__()
 

--- a/pyrogram/types/chat_drafts/draft_message.py
+++ b/pyrogram/types/chat_drafts/draft_message.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Optional, List, Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -83,7 +83,7 @@ class DraftMessage(Object):
         reply_to_message: "types.Message" = None,
         date: datetime = None,
         text: Str = None,
-        entities: List["types.MessageEntity"] = None,
+        entities: list["types.MessageEntity"] = None,
         link_preview_options: "types.LinkPreviewOptions" = None,
         effect_id: str = None,
         video_note: "types.VideoNote" = None,

--- a/pyrogram/types/chat_topics/forum_topic.py
+++ b/pyrogram/types/chat_topics/forum_topic.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Optional, List, Union
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums

--- a/pyrogram/types/chat_topics/forum_topic_created.py
+++ b/pyrogram/types/chat_topics/forum_topic_created.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List, Union
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums

--- a/pyrogram/types/chat_topics/forum_topic_edited.py
+++ b/pyrogram/types/chat_topics/forum_topic_edited.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List, Union
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums

--- a/pyrogram/types/inline_mode/inline_query.py
+++ b/pyrogram/types/inline_mode/inline_query.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Match
+from typing import Match
 
 import pyrogram
 from pyrogram import raw
@@ -64,7 +64,7 @@ class InlineQuery(Object, Update):
         offset: str,
         chat_type: "enums.ChatType",
         location: "types.Location" = None,
-        matches: List[Match] = None
+        matches: list[Match] = None
     ):
         super().__init__(client)
 
@@ -108,7 +108,7 @@ class InlineQuery(Object, Update):
 
     async def answer(
         self,
-        results: List["types.InlineQueryResult"],
+        results: list["types.InlineQueryResult"],
         cache_time: int = 300,
         is_gallery: bool = False,
         is_personal: bool = False,

--- a/pyrogram/types/inline_mode/inline_query.py
+++ b/pyrogram/types/inline_mode/inline_query.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Match
+import re
 
 import pyrogram
 from pyrogram import raw
@@ -64,7 +64,7 @@ class InlineQuery(Object, Update):
         offset: str,
         chat_type: "enums.ChatType",
         location: "types.Location" = None,
-        matches: list[Match] = None
+        matches: list[re.Match] = None
     ):
         super().__init__(client)
 

--- a/pyrogram/types/inline_mode/inline_query.py
+++ b/pyrogram/types/inline_mode/inline_query.py
@@ -19,8 +19,7 @@
 import re
 
 import pyrogram
-from pyrogram import raw
-from pyrogram import types, enums
+from pyrogram import raw, types, enums
 from ..object import Object
 from ..update import Update
 

--- a/pyrogram/types/inline_mode/inline_query_result_animation.py
+++ b/pyrogram/types/inline_mode/inline_query_result_animation.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -92,7 +92,7 @@ class InlineQueryResultAnimation(InlineQueryResult):
         description: str = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         input_message_content: "types.InputMessageContent" = None

--- a/pyrogram/types/inline_mode/inline_query_result_audio.py
+++ b/pyrogram/types/inline_mode/inline_query_result_audio.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Optional
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -73,7 +73,7 @@ class InlineQueryResultAudio(InlineQueryResult):
         audio_duration: int = 0,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         input_message_content: "types.InputMessageContent" = None
     ):

--- a/pyrogram/types/inline_mode/inline_query_result_cached_animation.py
+++ b/pyrogram/types/inline_mode/inline_query_result_cached_animation.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -69,7 +69,7 @@ class InlineQueryResultCachedAnimation(InlineQueryResult):
         title: str = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         input_message_content: "types.InputMessageContent" = None

--- a/pyrogram/types/inline_mode/inline_query_result_cached_audio.py
+++ b/pyrogram/types/inline_mode/inline_query_result_cached_audio.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -61,7 +61,7 @@ class InlineQueryResultCachedAudio(InlineQueryResult):
         id: str = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         input_message_content: "types.InputMessageContent" = None
     ):

--- a/pyrogram/types/inline_mode/inline_query_result_cached_document.py
+++ b/pyrogram/types/inline_mode/inline_query_result_cached_document.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -69,7 +69,7 @@ class InlineQueryResultCachedDocument(InlineQueryResult):
         description: str = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         input_message_content: "types.InputMessageContent" = None
     ):

--- a/pyrogram/types/inline_mode/inline_query_result_cached_photo.py
+++ b/pyrogram/types/inline_mode/inline_query_result_cached_photo.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -72,7 +72,7 @@ class InlineQueryResultCachedPhoto(InlineQueryResult):
         description: str = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         input_message_content: "types.InputMessageContent" = None

--- a/pyrogram/types/inline_mode/inline_query_result_cached_video.py
+++ b/pyrogram/types/inline_mode/inline_query_result_cached_video.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -73,7 +73,7 @@ class InlineQueryResultCachedVideo(InlineQueryResult):
         description: str = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         input_message_content: "types.InputMessageContent" = None

--- a/pyrogram/types/inline_mode/inline_query_result_cached_voice.py
+++ b/pyrogram/types/inline_mode/inline_query_result_cached_voice.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -66,7 +66,7 @@ class InlineQueryResultCachedVoice(InlineQueryResult):
         title: str = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         input_message_content: "types.InputMessageContent" = None
     ):

--- a/pyrogram/types/inline_mode/inline_query_result_photo.py
+++ b/pyrogram/types/inline_mode/inline_query_result_photo.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -86,7 +86,7 @@ class InlineQueryResultPhoto(InlineQueryResult):
         description: str = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         input_message_content: "types.InputMessageContent" = None

--- a/pyrogram/types/inline_mode/inline_query_result_video.py
+++ b/pyrogram/types/inline_mode/inline_query_result_video.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -94,7 +94,7 @@ class InlineQueryResultVideo(InlineQueryResult):
         description: str = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         input_message_content: "types.InputMessageContent" = None

--- a/pyrogram/types/inline_mode/inline_query_result_voice.py
+++ b/pyrogram/types/inline_mode/inline_query_result_voice.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Optional
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -69,7 +69,7 @@ class InlineQueryResultVoice(InlineQueryResult):
         voice_duration: int = 0,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         input_message_content: "types.InputMessageContent" = None
     ):

--- a/pyrogram/types/input_media/input_media.py
+++ b/pyrogram/types/input_media/input_media.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from ..messages_and_media import MessageEntity
 from ..object import Object
@@ -41,7 +41,7 @@ class InputMedia(Object):
         media: Union[str, "io.BytesIO"],
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List[MessageEntity] = None
+        caption_entities: list[MessageEntity] = None
     ):
         super().__init__()
 

--- a/pyrogram/types/input_media/input_media_animation.py
+++ b/pyrogram/types/input_media/input_media_animation.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
-from typing import Optional, List, Union
+from typing import Optional, Union
 
 from .input_media import InputMedia
 from ..messages_and_media import MessageEntity
@@ -74,7 +74,7 @@ class InputMediaAnimation(InputMedia):
         thumb: Union[str, "io.BytesIO"] = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List[MessageEntity] = None,
+        caption_entities: list[MessageEntity] = None,
         show_caption_above_media: bool = None,
         width: int = 0,
         height: int = 0,

--- a/pyrogram/types/input_media/input_media_audio.py
+++ b/pyrogram/types/input_media/input_media_audio.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
-from typing import Optional, List, Union
+from typing import Optional, Union
 
 from .input_media import InputMedia
 from ..messages_and_media import MessageEntity
@@ -74,7 +74,7 @@ class InputMediaAudio(InputMedia):
         thumb: Union[str, "io.BytesIO"] = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List[MessageEntity] = None,
+        caption_entities: list[MessageEntity] = None,
         duration: int = 0,
         performer: str = "",
         title: str = "",

--- a/pyrogram/types/input_media/input_media_document.py
+++ b/pyrogram/types/input_media/input_media_document.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
-from typing import Optional, List, Union
+from typing import Optional, Union
 
 from .input_media import InputMedia
 from ..messages_and_media import MessageEntity
@@ -63,7 +63,7 @@ class InputMediaDocument(InputMedia):
         thumb: Union[str, "io.BytesIO"] = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List[MessageEntity] = None,
+        caption_entities: list[MessageEntity] = None,
         file_name: str = None
     ):
         super().__init__(media, caption, parse_mode, caption_entities)

--- a/pyrogram/types/input_media/input_media_photo.py
+++ b/pyrogram/types/input_media/input_media_photo.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
-from typing import Optional, List, Union
+from typing import Optional, Union
 
 from .input_media import InputMedia
 from ..messages_and_media import MessageEntity
@@ -59,7 +59,7 @@ class InputMediaPhoto(InputMedia):
         media: Union[str, "io.BytesIO"],
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List[MessageEntity] = None,
+        caption_entities: list[MessageEntity] = None,
         show_caption_above_media: bool = None,
         has_spoiler: bool = None
     ):

--- a/pyrogram/types/input_media/input_media_video.py
+++ b/pyrogram/types/input_media/input_media_video.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
-from typing import Optional, List, Union
+from typing import Optional, Union
 
 from .input_media import InputMedia
 from ..messages_and_media import MessageEntity
@@ -86,7 +86,7 @@ class InputMediaVideo(InputMedia):
         thumb: Union[str, "io.BytesIO"] = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List[MessageEntity] = None,
+        caption_entities: list[MessageEntity] = None,
         show_caption_above_media: bool = None,
         width: int = 0,
         height: int = 0,

--- a/pyrogram/types/input_message_content/external_reply_info.py
+++ b/pyrogram/types/input_message_content/external_reply_info.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List, Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import raw, types, utils, enums

--- a/pyrogram/types/input_message_content/input_invoice_message_content.py
+++ b/pyrogram/types/input_message_content/input_invoice_message_content.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Optional, List, Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import raw, types
@@ -98,10 +98,10 @@ class InputInvoiceMessageContent(InputMessageContent):
         description: str,
         payload: Union[str, bytes],
         currency: str,
-        prices: List["types.LabeledPrice"],
+        prices: list["types.LabeledPrice"],
         provider_token: Optional[str] = None,
         max_tip_amount: Optional[int] = None,
-        suggested_tip_amounts: List[int] = None,
+        suggested_tip_amounts: list[int] = None,
         provider_data: Optional[str] = None,
         photo_url: Optional[str] = None,
         photo_size: Optional[int] = None,

--- a/pyrogram/types/input_message_content/input_poll_option.py
+++ b/pyrogram/types/input_message_content/input_poll_option.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List
+from typing import Union
 
 import pyrogram
 from pyrogram import raw, utils, types, enums
@@ -46,7 +46,7 @@ class InputPollOption(Object):
         *,
         text: str,
         text_parse_mode: "enums.ParseMode" = None,
-        text_entities: List["types.MessageEntity"] = None,
+        text_entities: list["types.MessageEntity"] = None,
     ):
         super().__init__()
 

--- a/pyrogram/types/input_message_content/input_text_message_content.py
+++ b/pyrogram/types/input_message_content/input_text_message_content.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Optional, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -48,7 +48,7 @@ class InputTextMessageContent(InputMessageContent):
         self,
         message_text: str,
         parse_mode: Optional["enums.ParseMode"] = None,
-        entities: List["types.MessageEntity"] = None,
+        entities: list["types.MessageEntity"] = None,
         link_preview_options: "types.LinkPreviewOptions" = None,
         disable_web_page_preview: bool = None
     ):

--- a/pyrogram/types/input_message_content/reply_parameters.py
+++ b/pyrogram/types/input_message_content/reply_parameters.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List, Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -66,7 +66,7 @@ class ReplyParameters(Object):
         # TODO
         quote: str = None,
         quote_parse_mode: Optional["enums.ParseMode"] = None,
-        quote_entities: List["types.MessageEntity"] = None,
+        quote_entities: list["types.MessageEntity"] = None,
         quote_position: int = None,
     ):
         super().__init__()

--- a/pyrogram/types/input_message_content/text_quote.py
+++ b/pyrogram/types/input_message_content/text_quote.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List, Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -47,7 +47,7 @@ class TextQuote(Object):
         *,
         client: "pyrogram.Client" = None,
         text: str = None,
-        entities: List["types.MessageEntity"] = None,
+        entities: list["types.MessageEntity"] = None,
         position: int = None,
         is_manual: bool = None
     ):

--- a/pyrogram/types/input_paid_media/input_paid_media_photo.py
+++ b/pyrogram/types/input_paid_media/input_paid_media_photo.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
-from typing import Optional, List, Union
+from typing import Optional, Union
 
 from .input_paid_media import InputPaidMedia
 from ... import enums

--- a/pyrogram/types/input_paid_media/input_paid_media_video.py
+++ b/pyrogram/types/input_paid_media/input_paid_media_video.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
-from typing import Optional, List, Union
+from typing import Optional, Union
 
 from .input_paid_media import InputPaidMedia
 from ... import enums

--- a/pyrogram/types/input_paid_media/paid_media_info.py
+++ b/pyrogram/types/input_paid_media/paid_media_info.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
 from pyrogram import raw, types
 from ..object import Object
@@ -39,7 +37,7 @@ class PaidMediaInfo(Object):
         self,
         *,
         star_count: str,
-        paid_media: List["types.PaidMedia"]
+        paid_media: list["types.PaidMedia"]
     ):
         super().__init__()
 

--- a/pyrogram/types/messages_and_media/alternative_video.py
+++ b/pyrogram/types/messages_and_media/alternative_video.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import List
 
 import pyrogram
 from pyrogram import raw, utils
@@ -84,7 +83,7 @@ class AlternativeVideo(Object):
         file_size: int = None,
         supports_streaming: bool = None,
         date: datetime = None,
-        thumbs: List["types.Thumbnail"] = None
+        thumbs: list["types.Thumbnail"] = None
     ):
         super().__init__(client)
 

--- a/pyrogram/types/messages_and_media/animation.py
+++ b/pyrogram/types/messages_and_media/animation.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import List
 
 import pyrogram
 from pyrogram import raw, utils
@@ -75,7 +74,7 @@ class Animation(Object):
         mime_type: str = None,
         file_size: int = None,
         date: datetime = None,
-        thumbs: List["types.Thumbnail"] = None
+        thumbs: list["types.Thumbnail"] = None
     ):
         super().__init__(client)
 
@@ -128,7 +127,7 @@ class Animation(Object):
         if isinstance(video, raw.types.Photo):
             if not video.video_sizes:
                 return
-            video_sizes: List[raw.types.VideoSize] = []
+            video_sizes: list[raw.types.VideoSize] = []
             for p in video.video_sizes:
                 if isinstance(p, raw.types.VideoSize):
                     video_sizes.append(p)

--- a/pyrogram/types/messages_and_media/audio.py
+++ b/pyrogram/types/messages_and_media/audio.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import List
 
 import pyrogram
 from pyrogram import raw, utils
@@ -75,7 +74,7 @@ class Audio(Object):
         mime_type: str = None,
         file_size: int = None,
         date: datetime = None,
-        thumbs: List["types.Thumbnail"] = None
+        thumbs: list["types.Thumbnail"] = None
     ):
         super().__init__(client)
 

--- a/pyrogram/types/messages_and_media/document.py
+++ b/pyrogram/types/messages_and_media/document.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import List
 
 import pyrogram
 from pyrogram import raw, utils
@@ -63,7 +62,7 @@ class Document(Object):
         mime_type: str = None,
         file_size: int = None,
         date: datetime = None,
-        thumbs: List["types.Thumbnail"] = None
+        thumbs: list["types.Thumbnail"] = None
     ):
         super().__init__(client)
 

--- a/pyrogram/types/messages_and_media/gift_code.py
+++ b/pyrogram/types/messages_and_media/gift_code.py
@@ -16,7 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
 from pyrogram import raw, types, utils
 from ..object import Object
 from .message import Str
@@ -79,7 +78,7 @@ class GiftCode(Object):
         cryptocurrency: str = None,
         cryptocurrency_amount: int = None,
         caption: str = None,
-        caption_entities: List["types.MessageEntity"] = None
+        caption_entities: list["types.MessageEntity"] = None
     ):
         super().__init__()
 

--- a/pyrogram/types/messages_and_media/gifted_premium.py
+++ b/pyrogram/types/messages_and_media/gifted_premium.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from random import choice
-from typing import List
 
 from pyrogram import raw, types
 from ..object import Object
@@ -68,7 +67,7 @@ class GiftedPremium(Object):
         month_count: int = None,
         sticker: "types.Sticker" = None,
         caption: str = None,
-        caption_entities: List["types.MessageEntity"] = None
+        caption_entities: list["types.MessageEntity"] = None
     ):
         super().__init__()
 

--- a/pyrogram/types/messages_and_media/giveaway.py
+++ b/pyrogram/types/messages_and_media/giveaway.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import List
 
 import pyrogram
 
@@ -63,13 +62,13 @@ class Giveaway(Object):
         self,
         *,
         client: "pyrogram.Client" = None,
-        chats: List["types.Chat"],
+        chats: list["types.Chat"],
         winners_selection_date: datetime,
         winner_count: int,
         only_new_members: bool = None,
         has_public_winners: bool = None,
         prize_description: str = None,
-        country_codes: List[str] = None,
+        country_codes: list[str] = None,
         prize_star_count: int = None,
         premium_subscription_month_count: int = None
     ):

--- a/pyrogram/types/messages_and_media/giveaway_completed.py
+++ b/pyrogram/types/messages_and_media/giveaway_completed.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import List
 
 import pyrogram
 

--- a/pyrogram/types/messages_and_media/giveaway_created.py
+++ b/pyrogram/types/messages_and_media/giveaway_created.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import List
 
 import pyrogram
 

--- a/pyrogram/types/messages_and_media/giveaway_winners.py
+++ b/pyrogram/types/messages_and_media/giveaway_winners.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import List
 
 import pyrogram
 
@@ -76,7 +75,7 @@ class GiveawayWinners(Object):
         giveaway_message_id: int,
         winners_selection_date: datetime,
         winner_count: int,
-        winners: List["types.User"],
+        winners: list["types.User"],
         additional_chat_count: int = None,
         prize_star_count: int = None,
         premium_subscription_month_count: int = None,

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -18,9 +18,10 @@
 
 import io
 import logging
+import re
 from datetime import datetime
 from functools import partial
-from typing import Match, Union, Optional, Callable
+from typing import Union, Optional, Callable
 
 import pyrogram
 from pyrogram import raw, enums, types, utils
@@ -533,7 +534,7 @@ class Message(Object, Update):
         views: int = None,
         forwards: int = None,
         outgoing: bool = None,
-        matches: list[Match] = None,
+        matches: list[re.Match] = None,
         command: list[str] = None,
         reactions: list["types.Reaction"] = None,
         custom_action: str = None,

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -20,7 +20,7 @@ import io
 import logging
 from datetime import datetime
 from functools import partial
-from typing import List, Match, Union, Optional, Callable
+from typing import Match, Union, Optional, Callable
 
 import pyrogram
 from pyrogram import raw, enums, types, utils
@@ -36,7 +36,7 @@ class Str(str):
     def __init__(self, *args):
         super().__init__()
 
-        self.entities: Optional[List["types.MessageEntity"]] = None
+        self.entities: Optional[list["types.MessageEntity"]] = None
 
     def init(self, entities):
         self.entities = entities
@@ -450,7 +450,7 @@ class Message(Object, Update):
         media_group_id: str = None,
         author_signature: str = None,
         text: Str = None,
-        entities: List["types.MessageEntity"] = None,
+        entities: list["types.MessageEntity"] = None,
         link_preview_options: "types.LinkPreviewOptions" = None,
         effect_id: str = None,
         animation: "types.Animation" = None,
@@ -461,11 +461,11 @@ class Message(Object, Update):
         sticker: "types.Sticker" = None,
         story: "types.Story" = None,
         video: "types.Video" = None,
-        alternative_videos: List["types.AlternativeVideo"] = None,
+        alternative_videos: list["types.AlternativeVideo"] = None,
         video_note: "types.VideoNote" = None,
         voice: "types.Voice" = None,
         caption: Str = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         has_media_spoiler: bool = None,
         contact: "types.Contact" = None,
@@ -474,7 +474,7 @@ class Message(Object, Update):
         poll: "types.Poll" = None,
         venue: "types.Venue" = None,
         location: "types.Location" = None,
-        new_chat_members: List["types.User"] = None,
+        new_chat_members: list["types.User"] = None,
         left_chat_member: "types.User" = None,
         new_chat_title: str = None,
         new_chat_photo: "types.Photo" = None,
@@ -533,9 +533,9 @@ class Message(Object, Update):
         views: int = None,
         forwards: int = None,
         outgoing: bool = None,
-        matches: List[Match] = None,
-        command: List[str] = None,
-        reactions: List["types.Reaction"] = None,
+        matches: list[Match] = None,
+        command: list[str] = None,
+        reactions: list["types.Reaction"] = None,
         custom_action: str = None,
         contact_registered: "types.ContactRegistered" = None,
         chat_join_type: "enums.ChatJoinType" = None,
@@ -1451,7 +1451,7 @@ class Message(Object, Update):
                 return f"https://t.me/{self.chat.username}{f'/{self.message_thread_id}' if self.message_thread_id else ''}/{self.id}"
             return f"https://t.me/c/{utils.get_channel_id(self.chat.id)}{f'/{self.message_thread_id}' if self.message_thread_id else ''}/{self.id}"
 
-    async def get_media_group(self) -> List["types.Message"]:
+    async def get_media_group(self) -> list["types.Message"]:
         """Bound method *get_media_group* of :obj:`~pyrogram.types.Message`.
         
         Use as a shortcut for:
@@ -1485,7 +1485,7 @@ class Message(Object, Update):
         text: str = None,
         quote: bool = None,
         parse_mode: Optional["enums.ParseMode"] = None,
-        entities: List["types.MessageEntity"] = None,
+        entities: list["types.MessageEntity"] = None,
         link_preview_options: "types.LinkPreviewOptions" = None,
         disable_notification: bool = None,
         protect_content: bool = None,
@@ -1615,7 +1615,7 @@ class Message(Object, Update):
         quote: bool = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         unsave: bool = False,
         has_spoiler: bool = None,
@@ -1817,7 +1817,7 @@ class Message(Object, Update):
         quote: bool = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         duration: int = 0,
         performer: str = None,
         title: str = None,
@@ -1997,7 +1997,7 @@ class Message(Object, Update):
         quote: bool = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         disable_notification: bool = None,
         message_effect_id: int = None,
@@ -2303,7 +2303,7 @@ class Message(Object, Update):
         thumb: Union[str, "io.BytesIO"] = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         file_name: str = None,
         disable_content_type_detection: bool = None,
         disable_notification: bool = None,
@@ -2765,7 +2765,7 @@ class Message(Object, Update):
 
     async def reply_media_group(
         self,
-        media: List[Union["types.InputMediaPhoto", "types.InputMediaVideo"]],
+        media: list[Union["types.InputMediaPhoto", "types.InputMediaVideo"]],
         quote: bool = None,
         disable_notification: bool = None,
         message_effect_id: int = None,
@@ -2775,7 +2775,7 @@ class Message(Object, Update):
         protect_content: bool = None,
         allow_paid_broadcast: bool = None,
         reply_to_message_id: int = None
-    ) -> List["types.Message"]:
+    ) -> list["types.Message"]:
         """Bound method *reply_media_group* of :obj:`~pyrogram.types.Message`.
 
         Use as a shortcut for:
@@ -2865,7 +2865,7 @@ class Message(Object, Update):
         quote: bool = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         has_spoiler: bool = None,
         ttl_seconds: int = None,
@@ -3038,16 +3038,16 @@ class Message(Object, Update):
     async def reply_poll(
         self,
         question: str,
-        options: List[str],
+        options: list[str],
         question_parse_mode: "enums.ParseMode" = None,
-        question_entities: List["types.MessageEntity"] = None,
+        question_entities: list["types.MessageEntity"] = None,
         is_anonymous: bool = True,
         type: "enums.PollType" = enums.PollType.REGULAR,
         allows_multiple_answers: bool = None,
         correct_option_id: int = None,
         explanation: str = None,
         explanation_parse_mode: "enums.ParseMode" = None,
-        explanation_entities: List["types.MessageEntity"] = None,
+        explanation_entities: list["types.MessageEntity"] = None,
         open_period: int = None,
         close_date: datetime = None,
         is_closed: bool = None,
@@ -3234,7 +3234,7 @@ class Message(Object, Update):
         quote: bool = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         emoji: str = None,
         disable_notification: bool = None,
         protect_content: bool = None,
@@ -3524,7 +3524,7 @@ class Message(Object, Update):
         quote: bool = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         duration: int = 0,
         width: int = 0,
@@ -3750,7 +3750,7 @@ class Message(Object, Update):
         ] = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         send_as: Union[int, str] = None,
         schedule_date: datetime = None,
         ttl_seconds: int = None,
@@ -3916,7 +3916,7 @@ class Message(Object, Update):
         quote: bool = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         duration: int = 0,
         disable_notification: bool = None,
         protect_content: bool = None,
@@ -4088,12 +4088,12 @@ class Message(Object, Update):
         description: str,
         payload: Union[str, bytes],
         currency: str,
-        prices: List["types.LabeledPrice"],
+        prices: list["types.LabeledPrice"],
         message_thread_id: int = None,
         quote: bool = None,
         provider_token: str = None,
         max_tip_amount: int = None,
-        suggested_tip_amounts: List[int] = None,
+        suggested_tip_amounts: list[int] = None,
         start_parameter: str = None,
         provider_data: str = None,
         photo_url: str = "",
@@ -4121,7 +4121,7 @@ class Message(Object, Update):
         ] = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None
+        caption_entities: list["types.MessageEntity"] = None
     ) -> "Message":
         """Bound method *reply_invoice* of :obj:`~pyrogram.types.Message`.
 
@@ -4288,7 +4288,7 @@ class Message(Object, Update):
         self,
         text: str,
         parse_mode: Optional["enums.ParseMode"] = None,
-        entities: List["types.MessageEntity"] = None,
+        entities: list["types.MessageEntity"] = None,
         link_preview_options: "types.LinkPreviewOptions" = None,
         reply_markup: "types.InlineKeyboardMarkup" = None,
         disable_web_page_preview: bool = None
@@ -4354,7 +4354,7 @@ class Message(Object, Update):
         self,
         caption: str,
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         reply_markup: "types.InlineKeyboardMarkup" = None
     ) -> "Message":
         """Bound method *edit_caption* of :obj:`~pyrogram.types.Message`.
@@ -4495,7 +4495,7 @@ class Message(Object, Update):
         file_id: str,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         schedule_date: datetime = None,
         has_spoiler: bool = None,
         reply_markup: "types.InlineKeyboardMarkup" = None
@@ -4563,7 +4563,7 @@ class Message(Object, Update):
         drop_media_captions: bool = None,
         send_as: Union[int, str] = None,
         schedule_date: datetime = None
-    ) -> Union["types.Message", List["types.Message"]]:
+    ) -> Union["types.Message", list["types.Message"]]:
         """Bound method *forward* of :obj:`~pyrogram.types.Message`.
 
         Use as a shortcut for:
@@ -4641,7 +4641,7 @@ class Message(Object, Update):
         chat_id: Union[int, str],
         caption: str = None,
         parse_mode: Optional["enums.ParseMode"] = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         show_caption_above_media: bool = None,
         disable_notification: bool = None,
         reply_parameters: "types.ReplyParameters" = None,
@@ -4658,7 +4658,7 @@ class Message(Object, Update):
         allow_paid_broadcast: bool = None,
         message_thread_id: int = None,
         reply_to_message_id: int = None
-    ) -> Union["types.Message", List["types.Message"]]:
+    ) -> Union["types.Message", list["types.Message"]]:
         """Bound method *copy* of :obj:`~pyrogram.types.Message`.
 
         Use as a shortcut for:
@@ -5174,7 +5174,7 @@ class Message(Object, Update):
         reaction: Union[
             int,
             str,
-            List[Union[int, str, "types.ReactionType"]]
+            list[Union[int, str, "types.ReactionType"]]
         ] = None,
         is_big: bool = False,
         add_to_recent: bool = True
@@ -5221,7 +5221,7 @@ class Message(Object, Update):
         """
         sr = None
 
-        if isinstance(reaction, List):
+        if isinstance(reaction, list):
             sr = []
             for i in reaction:
                 if isinstance(i, types.ReactionType):
@@ -5638,8 +5638,8 @@ class Message(Object, Update):
 
     async def pay(self) -> Union[
         bool,
-        List["types.PaidMediaPhoto"],
-        List["types.PaidMediaVideo"]
+        list["types.PaidMediaPhoto"],
+        list["types.PaidMediaVideo"]
     ]:
         """Bound method *pay* of :obj:`~pyrogram.types.Message`.
 

--- a/pyrogram/types/messages_and_media/message_reaction_count_updated.py
+++ b/pyrogram/types/messages_and_media/message_reaction_count_updated.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Optional, Dict, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -51,7 +51,7 @@ class MessageReactionCountUpdated(Object, Update):
         chat: "types.Chat",
         message_id: int,
         date: datetime,
-        reactions: List["types.ReactionCount"]
+        reactions: list["types.ReactionCount"]
     ):
         super().__init__(client)
 
@@ -64,8 +64,8 @@ class MessageReactionCountUpdated(Object, Update):
     def _parse(
         client: "pyrogram.Client",
         update: "raw.types.UpdateBotMessageReactions",
-        users: Dict[int, "raw.types.User"],
-        chats: Dict[int, "raw.types.Chat"]
+        users: dict[int, "raw.types.User"],
+        chats: dict[int, "raw.types.Chat"]
     ) -> "MessageReactionUpdated":
         chat = None
         peer_id = utils.get_peer_id(update.peer)

--- a/pyrogram/types/messages_and_media/message_reaction_updated.py
+++ b/pyrogram/types/messages_and_media/message_reaction_updated.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Optional, Dict, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -65,8 +65,8 @@ class MessageReactionUpdated(Object, Update):
         user: "types.User",
         actor_chat: "types.Chat",
         date: datetime,
-        old_reaction: List["types.ReactionType"],
-        new_reaction: List["types.ReactionType"]
+        old_reaction: list["types.ReactionType"],
+        new_reaction: list["types.ReactionType"]
     ):
         super().__init__(client)
 
@@ -82,8 +82,8 @@ class MessageReactionUpdated(Object, Update):
     def _parse(
         client: "pyrogram.Client",
         update: "raw.types.UpdateBotMessageReaction",
-        users: Dict[int, "raw.types.User"],
-        chats: Dict[int, "raw.types.Chat"]
+        users: dict[int, "raw.types.User"],
+        chats: dict[int, "raw.types.Chat"]
     ) -> "MessageReactionUpdated":
         chat = None
         peer_id = utils.get_peer_id(update.peer)

--- a/pyrogram/types/messages_and_media/message_reactions.py
+++ b/pyrogram/types/messages_and_media/message_reactions.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types
@@ -35,7 +35,7 @@ class MessageReactions(Object):
         self,
         *,
         client: "pyrogram.Client" = None,
-        reactions: Optional[List["types.Reaction"]] = None,
+        reactions: Optional[list["types.Reaction"]] = None,
     ):
         super().__init__(client)
 

--- a/pyrogram/types/messages_and_media/photo.py
+++ b/pyrogram/types/messages_and_media/photo.py
@@ -68,7 +68,7 @@ class Photo(Object):
         date: datetime,
         ttl_seconds: int = None,
         has_spoiler: bool = None,
-        thumbs: List["types.Thumbnail"] = None
+        thumbs: list["types.Thumbnail"] = None
     ):
         super().__init__(client)
 
@@ -90,7 +90,7 @@ class Photo(Object):
         has_spoiler: bool = None,
     ) -> "Photo":
         if isinstance(photo, raw.types.Photo):
-            photos: List[raw.types.PhotoSize] = []
+            photos: list[raw.types.PhotoSize] = []
 
             for p in photo.sizes:
                 if isinstance(p, raw.types.PhotoSize):

--- a/pyrogram/types/messages_and_media/photo.py
+++ b/pyrogram/types/messages_and_media/photo.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import List
 
 import pyrogram
 from pyrogram import raw, utils

--- a/pyrogram/types/messages_and_media/poll.py
+++ b/pyrogram/types/messages_and_media/poll.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import List, Union, Optional
+from typing import Union, Optional
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -96,7 +96,7 @@ class Poll(Object, Update):
         chosen_option_id: Optional[int] = None,
         correct_option_id: Optional[int] = None,
         explanation: Optional[str] = None,
-        explanation_entities: Optional[List["types.MessageEntity"]] = None,
+        explanation_entities: Optional[list["types.MessageEntity"]] = None,
         open_period: Optional[int] = None,
         close_date: Optional[datetime] = None,
     ):

--- a/pyrogram/types/messages_and_media/poll.py
+++ b/pyrogram/types/messages_and_media/poll.py
@@ -86,8 +86,8 @@ class Poll(Object, Update):
         client: "pyrogram.Client" = None,
         id: str,
         question: str,
-        options: List["types.PollOption"],
-        question_entities: List["types.MessageEntity"] = None,
+        options: list["types.PollOption"],
+        question_entities: list["types.MessageEntity"] = None,
         total_voter_count: int,
         is_closed: bool,
         is_anonymous: bool = None,
@@ -122,7 +122,7 @@ class Poll(Object, Update):
     def _parse(client, media_poll: Union["raw.types.MessageMediaPoll", "raw.types.UpdateMessagePoll"]) -> "Poll":
         poll: raw.types.Poll = media_poll.poll
         poll_results: raw.types.PollResults = media_poll.results
-        results: List[raw.types.PollAnswerVoters] = poll_results.results
+        results: list[raw.types.PollAnswerVoters] = poll_results.results
 
         chosen_option_id = None
         correct_option_id = None

--- a/pyrogram/types/messages_and_media/poll_answer.py
+++ b/pyrogram/types/messages_and_media/poll_answer.py
@@ -48,7 +48,7 @@ class PollAnswer(Object, Update):
         *,
         client: "pyrogram.Client" = None,
         poll_id: str,
-        option_ids: List[int],
+        option_ids: list[int],
         user: Optional["types.User"] = None,
         voter_chat: Optional["types.Chat"] = None,
     ):

--- a/pyrogram/types/messages_and_media/poll_answer.py
+++ b/pyrogram/types/messages_and_media/poll_answer.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Optional
+from typing import Optional
 
 import pyrogram
 from pyrogram import enums, raw, types, utils

--- a/pyrogram/types/messages_and_media/poll_option.py
+++ b/pyrogram/types/messages_and_media/poll_option.py
@@ -47,7 +47,7 @@ class PollOption(Object):
         *,
         client: "pyrogram.Client" = None,
         text: str,
-        text_entities: List["types.MessageEntity"],
+        text_entities: list["types.MessageEntity"],
         voter_count: int,
         data: bytes
     ):

--- a/pyrogram/types/messages_and_media/poll_option.py
+++ b/pyrogram/types/messages_and_media/poll_option.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
 from pyrogram import types
 

--- a/pyrogram/types/messages_and_media/sponsored_message.py
+++ b/pyrogram/types/messages_and_media/sponsored_message.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
 from pyrogram import raw, types
 

--- a/pyrogram/types/messages_and_media/sponsored_message.py
+++ b/pyrogram/types/messages_and_media/sponsored_message.py
@@ -75,7 +75,7 @@ class SponsoredMessage(Object):
         title: str,
         content: str,
         button_text: str,
-        entities: List["types.MessageEntity"] = None,
+        entities: list["types.MessageEntity"] = None,
         photo: "types.Photo" = None,
         is_recommended: bool = None,
         can_be_reported: bool = None,

--- a/pyrogram/types/messages_and_media/sticker.py
+++ b/pyrogram/types/messages_and_media/sticker.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import List, Dict, Type
+from typing import Type
 
 import pyrogram
 from pyrogram import raw, utils
@@ -90,7 +90,7 @@ class Sticker(Object):
         date: datetime = None,
         emoji: str = None,
         set_name: str = None,
-        thumbs: List["types.Thumbnail"] = None
+        thumbs: list["types.Thumbnail"] = None
     ):
         super().__init__(client)
 
@@ -148,7 +148,7 @@ class Sticker(Object):
     async def _parse(
         client,
         sticker: "raw.types.Document",
-        document_attributes: Dict[Type["raw.base.DocumentAttribute"], "raw.base.DocumentAttribute"],
+        document_attributes: dict[Type["raw.base.DocumentAttribute"], "raw.base.DocumentAttribute"],
     ) -> "Sticker":
         sticker_attributes = (
             document_attributes[raw.types.DocumentAttributeSticker]

--- a/pyrogram/types/messages_and_media/sticker.py
+++ b/pyrogram/types/messages_and_media/sticker.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Type
 
 import pyrogram
 from pyrogram import raw, utils
@@ -148,7 +147,7 @@ class Sticker(Object):
     async def _parse(
         client,
         sticker: "raw.types.Document",
-        document_attributes: dict[Type["raw.base.DocumentAttribute"], "raw.base.DocumentAttribute"],
+        document_attributes: dict[type["raw.base.DocumentAttribute"], "raw.base.DocumentAttribute"],
     ) -> "Sticker":
         sticker_attributes = (
             document_attributes[raw.types.DocumentAttributeSticker]

--- a/pyrogram/types/messages_and_media/story.py
+++ b/pyrogram/types/messages_and_media/story.py
@@ -106,10 +106,10 @@ class Story(Object, Update):
         edited: bool = None,
         pinned: bool = None,
         caption: Str = None,
-        caption_entities: List["types.MessageEntity"] = None,
+        caption_entities: list["types.MessageEntity"] = None,
         views: int = None,
         forwards: int = None,
-        reactions: List["types.Reaction"] = None,
+        reactions: list["types.Reaction"] = None,
         skipped: bool = None,
         deleted: bool = None,
         _raw = None

--- a/pyrogram/types/messages_and_media/story.py
+++ b/pyrogram/types/messages_and_media/story.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import List, Union, Callable
+from typing import Union, Callable
 
 import pyrogram
 from pyrogram import raw, utils, types, enums
@@ -411,7 +411,7 @@ class Story(Object, Update):
         """
         sr = None
 
-        if isinstance(reaction, List):
+        if isinstance(reaction, list):
             sr = []
             for i in reaction:
                 if isinstance(i, types.ReactionType):

--- a/pyrogram/types/messages_and_media/thumbnail.py
+++ b/pyrogram/types/messages_and_media/thumbnail.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import raw
@@ -64,7 +64,7 @@ class Thumbnail(Object):
         self.file_size = file_size
 
     @staticmethod
-    def _parse(client, media: Union["raw.types.Photo", "raw.types.Document"]) -> Optional[List["Thumbnail"]]:
+    def _parse(client, media: Union["raw.types.Photo", "raw.types.Document"]) -> Optional[list["Thumbnail"]]:
         if isinstance(media, raw.types.Photo):
             raw_thumbs = [i for i in media.sizes if isinstance(i, raw.types.PhotoSize)]
             raw_thumbs.sort(key=lambda p: p.size)

--- a/pyrogram/types/messages_and_media/translated_text.py
+++ b/pyrogram/types/messages_and_media/translated_text.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
 from pyrogram import raw, types
 

--- a/pyrogram/types/messages_and_media/translated_text.py
+++ b/pyrogram/types/messages_and_media/translated_text.py
@@ -40,7 +40,7 @@ class TranslatedText(Object):
         self,
         *,
         text: str,
-        entities: List["types.MessageEntity"] = None
+        entities: list["types.MessageEntity"] = None
     ):
         self.text = text
         self.entities = entities

--- a/pyrogram/types/messages_and_media/user_gift.py
+++ b/pyrogram/types/messages_and_media/user_gift.py
@@ -67,7 +67,7 @@ class UserGift(Object):
         client: "pyrogram.Client" = None,
         sender_user: Optional["types.User"] = None,
         text: Optional[str] = None,
-        entities: List["types.MessageEntity"] = None,
+        entities: list["types.MessageEntity"] = None,
         date: datetime,
         is_private: Optional[bool] = None,
         is_saved: Optional[bool] = None,

--- a/pyrogram/types/messages_and_media/user_gift.py
+++ b/pyrogram/types/messages_and_media/user_gift.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Optional, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils

--- a/pyrogram/types/messages_and_media/video.py
+++ b/pyrogram/types/messages_and_media/video.py
@@ -83,7 +83,7 @@ class Video(Object):
         supports_streaming: bool = None,
         ttl_seconds: int = None,
         date: datetime = None,
-        thumbs: List["types.Thumbnail"] = None
+        thumbs: list["types.Thumbnail"] = None
     ):
         super().__init__(client)
 

--- a/pyrogram/types/messages_and_media/video.py
+++ b/pyrogram/types/messages_and_media/video.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import List
 
 import pyrogram
 from pyrogram import raw, utils

--- a/pyrogram/types/messages_and_media/video_note.py
+++ b/pyrogram/types/messages_and_media/video_note.py
@@ -67,7 +67,7 @@ class VideoNote(Object):
         file_unique_id: str,
         length: int,
         duration: int,
-        thumbs: List["types.Thumbnail"] = None,
+        thumbs: list["types.Thumbnail"] = None,
         mime_type: str = None,
         file_size: int = None,
         date: datetime = None,

--- a/pyrogram/types/messages_and_media/video_note.py
+++ b/pyrogram/types/messages_and_media/video_note.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import List
 
 import pyrogram
 from pyrogram import raw, utils

--- a/pyrogram/types/object.py
+++ b/pyrogram/types/object.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import typing
+import re
 from datetime import datetime
 from enum import Enum
 from json import dumps
@@ -49,9 +49,7 @@ class Object:
         if isinstance(obj, bytes):
             return repr(obj)
 
-        # https://t.me/pyrogramchat/167281
-        # Instead of re.Match, which breaks for python <=3.6
-        if isinstance(obj, typing.Match):
+        if isinstance(obj, re.Match):
             return repr(obj)
 
         if isinstance(obj, Enum):

--- a/pyrogram/types/user_and_chats/chat.py
+++ b/pyrogram/types/user_and_chats/chat.py
@@ -18,7 +18,7 @@
 
 import io
 from datetime import datetime
-from typing import Union, List, Optional, AsyncGenerator
+from typing import Union, Optional, AsyncGenerator
 
 import pyrogram
 from pyrogram import raw, enums
@@ -247,7 +247,7 @@ class Chat(Object):
         first_name: str = None,
         last_name: str = None,
         photo: "types.ChatPhoto" = None,
-        active_usernames: List["types.Username"] = None,
+        active_usernames: list["types.Username"] = None,
         birthdate: "types.Birthdate" = None,
         business_intro: "types.BusinessIntro" = None,
         business_location: "types.BusinessLocation" = None,
@@ -262,9 +262,9 @@ class Chat(Object):
         sticker_set_name: str = None,
         custom_emoji_sticker_set_name: str = None,
         can_set_sticker_set: bool = None,
-        members: List["types.User"] = None,
+        members: list["types.User"] = None,
         members_count: int = None,
-        restrictions: List["types.Restriction"] = None,
+        restrictions: list["types.Restriction"] = None,
         permissions: "types.ChatPermissions" = None,
         distance: int = None,
         linked_chat: "types.Chat" = None,
@@ -1288,7 +1288,7 @@ class Chat(Object):
 
     async def add_members(
         self,
-        user_ids: Union[Union[int, str], List[Union[int, str]]],
+        user_ids: Union[Union[int, str], list[Union[int, str]]],
         forward_limit: int = 100
     ) -> bool:
         """Bound method *add_members* of :obj:`~pyrogram.types.Chat`.

--- a/pyrogram/types/user_and_chats/chat_admin_with_invite_links.py
+++ b/pyrogram/types/user_and_chats/chat_admin_with_invite_links.py
@@ -16,7 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Dict
 
 import pyrogram
 from pyrogram import raw
@@ -54,7 +53,7 @@ class ChatAdminWithInviteLinks(Object):
     def _parse(
         client: "pyrogram.Client",
         admin: "raw.types.ChatAdminWithInvites",
-        users: Dict[int, "raw.types.User"] = None
+        users: dict[int, "raw.types.User"] = None
     ) -> "ChatAdminWithInviteLinks":
         return ChatAdminWithInviteLinks(
             admin=types.User._parse(client, users[admin.admin_id]),

--- a/pyrogram/types/user_and_chats/chat_background.py
+++ b/pyrogram/types/user_and_chats/chat_background.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import List, Union
+from typing import Union
 
 import pyrogram
 from pyrogram import raw, utils
@@ -69,7 +69,7 @@ class ChatBackground(Object):
         file_size: int = None,
         date: datetime = None,
         slug: str = None,
-        thumbs: List["types.Thumbnail"] = None,
+        thumbs: list["types.Thumbnail"] = None,
         _raw: "raw.base.WallPaper" = None,
     ):
         super().__init__(client)

--- a/pyrogram/types/user_and_chats/chat_event.py
+++ b/pyrogram/types/user_and_chats/chat_event.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import List, Optional
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -193,8 +193,8 @@ class ChatEvent(Object):
         old_username: str = None,
         new_username: str = None,
 
-        old_usernames: List["types.Username"] = None,
-        new_usernames: List["types.Username"] = None,
+        old_usernames: list["types.Username"] = None,
+        new_usernames: list["types.Username"] = None,
 
         old_chat_permissions: "types.ChatPermissions" = None,
         new_chat_permissions: "types.ChatPermissions" = None,
@@ -320,8 +320,8 @@ class ChatEvent(Object):
     async def _parse(
         client: "pyrogram.Client",
         event: "raw.base.ChannelAdminLogEvent",
-        users: List["raw.base.User"],
-        chats: List["raw.base.Chat"]
+        users: list["raw.base.User"],
+        chats: list["raw.base.Chat"]
     ):
         users = {i.id: i for i in users}
         chats = {i.id: i for i in chats}
@@ -347,8 +347,8 @@ class ChatEvent(Object):
         old_username: Optional[str] = None
         new_username: Optional[str] = None
 
-        old_usernames: Optional[types.List[types.Username]] = None
-        new_usernames: Optional[types.List[types.Username]] = None
+        old_usernames: Optional[types.list[types.Username]] = None
+        new_usernames: Optional[types.list[types.Username]] = None
 
         old_chat_permissions: Optional[types.ChatPermissions] = None
         new_chat_permissions: Optional[types.ChatPermissions] = None

--- a/pyrogram/types/user_and_chats/chat_invite_link.py
+++ b/pyrogram/types/user_and_chats/chat_invite_link.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Dict
 from typing import Optional
 
 import pyrogram
@@ -119,7 +118,7 @@ class ChatInviteLink(Object):
     def _parse(
         client: "pyrogram.Client",
         invite: "raw.base.ExportedChatInvite",
-        users: Dict[int, "raw.types.User"] = None
+        users: dict[int, "raw.types.User"] = None
     ) -> Optional["ChatInviteLink"]:
         if not isinstance(invite, raw.types.ChatInviteExported):
             return None

--- a/pyrogram/types/user_and_chats/chat_join_request.py
+++ b/pyrogram/types/user_and_chats/chat_join_request.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Dict
 
 import pyrogram
 from pyrogram import raw, utils
@@ -73,8 +72,8 @@ class ChatJoinRequest(Object, Update):
     def _parse(
         client: "pyrogram.Client",
         update: "raw.types.UpdateBotChatInviteRequester",
-        users: Dict[int, "raw.types.User"],
-        chats: Dict[int, "raw.types.Chat"]
+        users: dict[int, "raw.types.User"],
+        chats: dict[int, "raw.types.Chat"]
     ) -> "ChatJoinRequest":
         chat_id = utils.get_raw_peer_id(update.peer)
         return ChatJoinRequest(

--- a/pyrogram/types/user_and_chats/chat_joiner.py
+++ b/pyrogram/types/user_and_chats/chat_joiner.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Dict
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -66,7 +65,7 @@ class ChatJoiner(Object):
     def _parse(
         client: "pyrogram.Client",
         joiner: "raw.base.ChatInviteImporter",
-        users: Dict[int, "raw.base.User"],
+        users: dict[int, "raw.base.User"],
     ) -> "ChatJoiner":
         return ChatJoiner(
             user=types.User._parse(client, users[joiner.user_id]),

--- a/pyrogram/types/user_and_chats/chat_member.py
+++ b/pyrogram/types/user_and_chats/chat_member.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Union, Dict
+from typing import Union
 
 import pyrogram
 from pyrogram import raw, types, utils, enums
@@ -111,8 +111,8 @@ class ChatMember(Object):
     def _parse(
         client: "pyrogram.Client",
         member: Union["raw.base.ChatParticipant", "raw.base.ChannelParticipant"],
-        users: Dict[int, "raw.base.User"],
-        chats: Dict[int, "raw.base.Chat"]
+        users: dict[int, "raw.base.User"],
+        chats: dict[int, "raw.base.Chat"]
     ) -> "ChatMember":
         # Chat participants
         if isinstance(member, raw.types.ChatParticipant):

--- a/pyrogram/types/user_and_chats/chat_member_updated.py
+++ b/pyrogram/types/user_and_chats/chat_member_updated.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Dict, Union
+from typing import Union
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -84,8 +84,8 @@ class ChatMemberUpdated(Object, Update):
     def _parse(
         client: "pyrogram.Client",
         update: Union["raw.types.UpdateChatParticipant", "raw.types.UpdateChannelParticipant", "raw.types.UpdateBotStopped"],
-        users: Dict[int, "raw.types.User"],
-        chats: Dict[int, "raw.types.Chat"]
+        users: dict[int, "raw.types.User"],
+        chats: dict[int, "raw.types.Chat"]
     ) -> "ChatMemberUpdated":
         if isinstance(update, raw.types.UpdateBotStopped):
             from_user = types.User._parse(client, users[update.user_id])

--- a/pyrogram/types/user_and_chats/chat_reactions.py
+++ b/pyrogram/types/user_and_chats/chat_reactions.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, List
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw, types
@@ -45,7 +45,7 @@ class ChatReactions(Object):
         client: "pyrogram.Client" = None,
         all_are_enabled: Optional[bool] = None,
         allow_custom_emoji: Optional[bool] = None,
-        reactions: Optional[List["types.Reaction"]] = None,
+        reactions: Optional[list["types.Reaction"]] = None,
         max_reaction_count: int = 11,
     ):
         super().__init__(client)

--- a/pyrogram/types/user_and_chats/chat_shared.py
+++ b/pyrogram/types/user_and_chats/chat_shared.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
 from pyrogram import types
 from ..object import Object
@@ -39,7 +37,7 @@ class ChatShared(Object):
         self,
         *,
         request_id: int,
-        chats: List["types.Chat"]
+        chats: list["types.Chat"]
     ):
         super().__init__()
 

--- a/pyrogram/types/user_and_chats/group_call_participant.py
+++ b/pyrogram/types/user_and_chats/group_call_participant.py
@@ -17,7 +17,6 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Dict
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -119,8 +118,8 @@ class GroupCallParticipant(Object):
     def _parse(
         client: "pyrogram.Client",
         participant: "raw.types.GroupCallParticipant",
-        users: Dict[int, "raw.base.User"],
-        chats: Dict[int, "raw.base.Chat"]
+        users: dict[int, "raw.base.User"],
+        chats: dict[int, "raw.base.Chat"]
     ) -> "GroupCallParticipant":
         peer = participant.peer
         peer_id = utils.get_raw_peer_id(peer)

--- a/pyrogram/types/user_and_chats/user.py
+++ b/pyrogram/types/user_and_chats/user.py
@@ -18,7 +18,7 @@
 
 import html
 from datetime import datetime
-from typing import List, Optional
+from typing import Optional
 
 import pyrogram
 from pyrogram import enums, utils, raw, types
@@ -227,8 +227,8 @@ class User(Object, Update):
         dc_id: int = None,
         phone_number: str = None,
         photo: "types.ChatPhoto" = None,
-        active_usernames: List["types.Username"] = None,
-        restrictions: List["types.Restriction"] = None,
+        active_usernames: list["types.Username"] = None,
+        restrictions: list["types.Restriction"] = None,
         added_to_attachment_menu: bool = None,
         can_be_added_to_attachment_menu: bool = None,
         can_join_groups: bool = None,

--- a/pyrogram/types/user_and_chats/users_shared.py
+++ b/pyrogram/types/user_and_chats/users_shared.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List
-
 import pyrogram
 from pyrogram import types
 from ..object import Object
@@ -39,7 +37,7 @@ class UsersShared(Object):
         self,
         *,
         request_id: int,
-        users: List["types.User"]
+        users: list["types.User"]
     ):
         super().__init__()
 

--- a/pyrogram/types/user_and_chats/video_chat_participants_invited.py
+++ b/pyrogram/types/user_and_chats/video_chat_participants_invited.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Dict
-
 from pyrogram import raw, types
 from ..object import Object
 
@@ -33,7 +31,7 @@ class VideoChatParticipantsInvited(Object):
 
     def __init__(
         self, *,
-        users: List["types.User"]
+        users: list["types.User"]
     ):
         super().__init__()
 
@@ -43,7 +41,7 @@ class VideoChatParticipantsInvited(Object):
     def _parse(
         client,
         action: "raw.types.MessageActionInviteToGroupCall",
-        users: Dict[int, "raw.types.User"]
+        users: dict[int, "raw.types.User"]
     ) -> "VideoChatParticipantsInvited":
         users = [types.User._parse(client, users[i]) for i in action.users]
 

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -26,7 +26,7 @@ import struct
 from concurrent.futures.thread import ThreadPoolExecutor
 from datetime import datetime, timezone
 from getpass import getpass
-from typing import Union, List, Dict, Optional
+from typing import Union, Optional
 
 import pyrogram
 from pyrogram import raw, enums
@@ -95,7 +95,7 @@ async def parse_messages(
     replies: int = 1,
     business_connection_id: str = "",
     r: "raw.base.Updates" = None
-) -> List["types.Message"]:
+) -> list["types.Message"]:
     parsed_messages = []
 
     if not messages and r:
@@ -383,8 +383,8 @@ async def parse_text_entities(
     client: "pyrogram.Client",
     text: str,
     parse_mode: Optional[enums.ParseMode],
-    entities: List["types.MessageEntity"]
-) -> Dict[str, Union[str, List[raw.base.MessageEntity]]]:
+    entities: list["types.MessageEntity"]
+) -> dict[str, Union[str, list[raw.base.MessageEntity]]]:
     if entities:
         # Inject the client instance because parsing user mentions requires it
         for entity in entities:
@@ -400,7 +400,7 @@ async def parse_text_entities(
     }
 
 
-async def parse_deleted_messages(client, update, users, chats) -> List["types.Message"]:
+async def parse_deleted_messages(client, update, users, chats) -> list["types.Message"]:
     messages = update.messages
     channel_id = getattr(update, "channel_id", None)
     business_connection_id = getattr(update, "connection_id", None)


### PR DESCRIPTION
- [ ] Remove 3.7 and 3.8 from `.toml` and `.github` files
- [x] tuple to typing.Tuple
- [x] Rename list to typing.List
- [x] Rename dict to typing.Dict
- [x] Rename type to typing.Type
- [x] Rename re.Match to typing.Match