### PR TITLE
minor fix refunded_payment.py

### DIFF
--- a/pyrogram/types/business/refunded_payment.py
+++ b/pyrogram/types/business/refunded_payment.py
@@ -80,8 +80,8 @@ class RefundedPayment(Object):
         provider_payment_charge_id = refunded_payment.charge.provider_charge_id
 
         return RefundedPayment(
-            currency=successful_payment.currency,
-            total_amount=successful_payment.total_amount,
+            currency=refunded_payment.currency,
+            total_amount=refunded_payment.total_amount,
             invoice_payload=invoice_payload,
             telegram_payment_charge_id=telegram_payment_charge_id,
             provider_payment_charge_id=shipping_option_id


### PR DESCRIPTION
```log
name 'successful_payment' is not defined
Traceback (most recent call last):
  File "/home/keyiflerolsun/.local/lib/python3.12/site-packages/pyrogram/dispatcher.py", line 333, in handler_worker
    await parser(update, users, chats)
  File "/home/keyiflerolsun/.local/lib/python3.12/site-packages/pyrogram/dispatcher.py", line 107, in message_parser
    await pyrogram.types.Message._parse(
  File "/home/keyiflerolsun/.local/lib/python3.12/site-packages/pyrogram/types/messages_and_media/message.py", line 975, in _parse
    refunded_payment = types.RefundedPayment._parse(client, action)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/keyiflerolsun/.local/lib/python3.12/site-packages/pyrogram/types/business/refunded_payment.py", line 83, in _parse
    currency=successful_payment.currency,
             ^^^^^^^^^^^^^^^^^^
NameError: name 'successful_payment' is not defined
```