### PR TITLE
API 9.2

### DIFF
--- a/pyrogram/types/input_message_content/reply_parameters.py
+++ b/pyrogram/types/input_message_content/reply_parameters.py
@@ -56,9 +56,8 @@ class ReplyParameters(Object):
         quote_position (``int``, *optional*):
             Position of the quote in the original message in UTF-16 code units
         
-        direct_message_topic_id (``int``, *optional*):
-            TEMPORARY till the NEXT update.
-            Unique identifier of the topic in a channel direct messages chat administered by the current user; pass None if the chat is not a channel direct messages chat administered by the current user.
+        direct_messages_topic_id (``int``, *optional*):
+            Identifier of the direct messages topic to which the message will be sent; **required** if the message is sent to a direct messages chat; pass None if the chat is not a channel direct messages chat administered by the current user.
 
     """
 
@@ -73,7 +72,7 @@ class ReplyParameters(Object):
         quote_parse_mode: Optional["enums.ParseMode"] = None,
         quote_entities: list["types.MessageEntity"] = None,
         quote_position: int = None,
-        direct_message_topic_id: int = None,
+        direct_messages_topic_id: int = None,
     ):
         super().__init__()
 
@@ -84,4 +83,4 @@ class ReplyParameters(Object):
         self.quote_parse_mode = quote_parse_mode
         self.quote_entities = quote_entities
         self.quote_position = quote_position
-        self.direct_message_topic_id = direct_message_topic_id
+        self.direct_messages_topic_id = direct_messages_topic_id

--- a/pyrogram/types/input_message_content/reply_parameters.py
+++ b/pyrogram/types/input_message_content/reply_parameters.py
@@ -56,6 +56,9 @@ class ReplyParameters(Object):
         quote_position (``int``, *optional*):
             Position of the quote in the original message in UTF-16 code units
         
+        checklist_task_id (``int``, *optional*):
+            Identifier of the specific checklist task to be replied to.
+        
         direct_messages_topic_id (``int``, *optional*):
             Identifier of the direct messages topic to which the message will be sent; **required** if the message is sent to a direct messages chat; pass None if the chat is not a channel direct messages chat administered by the current user.
 
@@ -72,6 +75,7 @@ class ReplyParameters(Object):
         quote_parse_mode: Optional["enums.ParseMode"] = None,
         quote_entities: list["types.MessageEntity"] = None,
         quote_position: int = None,
+        checklist_task_id: int = None,
         direct_messages_topic_id: int = None,
     ):
         super().__init__()
@@ -83,4 +87,5 @@ class ReplyParameters(Object):
         self.quote_parse_mode = quote_parse_mode
         self.quote_entities = quote_entities
         self.quote_position = quote_position
+        self.checklist_task_id = checklist_task_id
         self.direct_messages_topic_id = direct_messages_topic_id

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -117,6 +117,9 @@ class Message(Object, Update):
         reply_to_story (:obj:`~pyrogram.types.Story`, *optional*):
             For replies to a story, the original story
 
+        reply_to_checklist_task_id (``int``, *optional*):
+            Identifier of the specific checklist task that is being replied to.
+
         via_bot (:obj:`~pyrogram.types.User`):
             The information of the bot that generated the message from an inline query of a user.
 
@@ -471,6 +474,7 @@ class Message(Object, Update):
         external_reply: "types.ExternalReplyInfo" = None,
         quote: "types.TextQuote" = None,
         reply_to_story: "types.Story" = None,
+        reply_to_checklist_task_id: int = None,
         via_bot: "types.User" = None,
         edit_date: datetime = None,
         has_protected_content: bool = None,
@@ -692,6 +696,7 @@ class Message(Object, Update):
         self.checklist = checklist
         self.checklist_tasks_done = checklist_tasks_done
         self.checklist_tasks_added = checklist_tasks_added
+        self.reply_to_checklist_task_id = reply_to_checklist_task_id
         self._raw = _raw
 
     @staticmethod
@@ -1490,6 +1495,7 @@ class Message(Object, Update):
             parsed_message.reply_to_message_id = None
             parsed_message.message_thread_id = None
             if isinstance(message.reply_to, raw.types.MessageReplyHeader):
+                parsed_message.reply_to_checklist_task_id = message.reply_to.todo_item_id
                 parsed_message.reply_to_message_id = message.reply_to.reply_to_msg_id
                 parsed_message.message_thread_id = message.reply_to.reply_to_top_id
                 if message.reply_to.forum_topic:

--- a/pyrogram/types/user_and_chats/chat.py
+++ b/pyrogram/types/user_and_chats/chat.py
@@ -87,6 +87,9 @@ class Chat(Object):
             Information about the corresponding channel chat; for direct messages chats only.
             Returned only in :meth:`~pyrogram.Client.get_chat`.
 
+        direct_messages_chat_id (``int``, *optional*):
+            Information about the corresponding Direct Messages chat; for channel chats only.
+
         available_reactions (:obj:`~pyrogram.types.ChatReactions`, *optional*):
             Available reactions in the chat.
             Returned only in :meth:`~pyrogram.Client.get_chat`.
@@ -296,6 +299,7 @@ class Chat(Object):
         personal_chat: "types.Chat" = None,
         personal_chat_message: "types.Message" = None,
         parent_chat: "types.Chat" = None,
+        direct_messages_chat_id: int = None,
         available_reactions: Optional["types.ChatReactions"] = None,
         accent_color: "types.ChatColor" = None,
         profile_color: "types.ChatColor" = None,
@@ -381,6 +385,7 @@ class Chat(Object):
         self.personal_chat = personal_chat
         self.personal_chat_message = personal_chat_message
         self.parent_chat = parent_chat
+        self.direct_messages_chat_id = direct_messages_chat_id
         self.birthdate = birthdate
         self.business_intro = business_intro
         self.business_location = business_location
@@ -564,6 +569,7 @@ class Chat(Object):
             paid_message_star_count=channel.send_paid_messages_stars,
             has_automatic_translation=channel.autotranslation,
             is_direct_messages=channel.monoforum,
+            direct_messages_chat_id=utils.get_channel_id(channel.linked_monoforum_id) if channel.linked_monoforum_id else None,
             _raw=channel
         )
 

--- a/pyrogram/types/user_and_chats/chat.py
+++ b/pyrogram/types/user_and_chats/chat.py
@@ -53,6 +53,9 @@ class Chat(Object):
         is_forum (``bool``, *optional*):
             True, if the supergroup chat is a forum
 
+        is_direct_messages (``bool``, *optional*):
+            True, if the chat is the direct messages chat of a channel.
+
         max_reaction_count (``int``):
             The maximum number of reactions that can be set on a message in the chat
 
@@ -79,6 +82,10 @@ class Chat(Object):
 
         personal_chat_message (:obj:`~pyrogram.types.Message`, *optional*):
             **TEMPORARY**: For private chats, the personal message_id in the ``personal_chat``.
+
+        parent_chat (:obj:`~pyrogram.types.Chat`, *optional*):
+            Information about the corresponding channel chat; for direct messages chats only.
+            Returned only in :meth:`~pyrogram.Client.get_chat`.
 
         available_reactions (:obj:`~pyrogram.types.ChatReactions`, *optional*):
             Available reactions in the chat.
@@ -288,6 +295,7 @@ class Chat(Object):
         send_as_chat: "types.Chat" = None,
         personal_chat: "types.Chat" = None,
         personal_chat_message: "types.Message" = None,
+        parent_chat: "types.Chat" = None,
         available_reactions: Optional["types.ChatReactions"] = None,
         accent_color: "types.ChatColor" = None,
         profile_color: "types.ChatColor" = None,
@@ -310,6 +318,7 @@ class Chat(Object):
         can_send_gift: bool = None,
         paid_message_star_count: int = None,
         has_automatic_translation: bool = None,
+        is_direct_messages: bool = None,
         _raw: Union[
             "raw.types.ChatInvite",
             "raw.types.Channel",
@@ -371,6 +380,7 @@ class Chat(Object):
         self.is_peak_preview = is_peak_preview
         self.personal_chat = personal_chat
         self.personal_chat_message = personal_chat_message
+        self.parent_chat = parent_chat
         self.birthdate = birthdate
         self.business_intro = business_intro
         self.business_location = business_location
@@ -384,6 +394,7 @@ class Chat(Object):
         self.can_send_gift = can_send_gift
         self.paid_message_star_count = paid_message_star_count
         self.has_automatic_translation = has_automatic_translation
+        self.is_direct_messages = is_direct_messages
         self._raw = _raw
 
     @staticmethod
@@ -552,6 +563,7 @@ class Chat(Object):
             emoji_status=types.EmojiStatus._parse(client, channel.emoji_status),
             paid_message_star_count=channel.send_paid_messages_stars,
             has_automatic_translation=channel.autotranslation,
+            is_direct_messages=channel.monoforum,
             _raw=channel
         )
 
@@ -700,6 +712,10 @@ class Chat(Object):
                 parsed_chat.gift_count = full_chat.stargifts_count
 
                 parsed_chat.can_send_gift = full_chat.stargifts_available
+
+                parent_chat_raw = chats.get(chat_raw.linked_monoforum_id, None)
+                if parent_chat_raw:
+                    parsed_chat.parent_chat = Chat._parse_channel_chat(client, parent_chat_raw)
 
             parsed_chat.message_auto_delete_time = getattr(full_chat, "ttl_period")
 

--- a/pyrogram/types/user_and_chats/chat_privileges.py
+++ b/pyrogram/types/user_and_chats/chat_privileges.py
@@ -28,22 +28,19 @@ class ChatPrivileges(Object):
             True, if the user's presence in the chat is hidden.
 
         can_manage_chat (``bool``, *optional*):
-            True, if the administrator can access the chat event log, boost list in channels, see channel members, report spam messages, see anonymous administrators in supergroups and ignore slow mode.
-            Implied by any other administrator privilege.
+            True, if the administrator can access the chat event log, get boost list, see hidden supergroup and channel members, report spam messages, ignore slow mode, and send messages to the chat without paying Telegram Stars. Implied by any other administrator privilege.
 
         can_delete_messages (``bool``, *optional*):
             True, if the administrator can delete messages of other users.
 
         can_manage_video_chats (``bool``, *optional*):
-            True, if the administrator can manage video chats
+            True, if the administrator can manage video chats.
 
         can_restrict_members (``bool``, *optional*):
-            True, if the administrator can restrict, ban or unban chat members, or access supergroup statistics
+            True, if the administrator can restrict, ban or unban chat members, or access supergroup statistics.
 
         can_promote_members (``bool``, *optional*):
-            True, if the administrator can add new administrators with a subset of his own privileges or demote
-            administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed
-            by the user).
+            True, if the administrator can add new administrators with a subset of their own privileges or demote administrators that they have promoted, directly or indirectly (promoted by administrators that were appointed by the user).
 
         can_change_info (``bool``, *optional*):
             True, if the user is allowed to change the chat title, photo and other settings.
@@ -52,29 +49,29 @@ class ChatPrivileges(Object):
             True, if the user is allowed to invite new users to the chat.
 
         can_post_messages (``bool``, *optional*):
-            True, if the administrator can post messages in the channel, or access channel statistics.
-            channels only
+            True, if the administrator can post messages in the channel, approve suggested posts, or access channel statistics; for channels only.
 
         can_edit_messages (``bool``, *optional*):
-            True, if the administrator can edit messages of other users and can pin messages.
-            channels only
+            True, if the administrator can edit messages of other users and can pin messages; for channels only.
 
         can_pin_messages (``bool``, *optional*):
-            True, if the user is allowed to pin messages.
-            groups and supergroups only
+            True, if the user is allowed to pin messages; for groups and supergroups only.
         
         can_post_stories (``bool``, *optional*):
             True, if the administrator can post stories to the chat.
 
         can_edit_stories (``bool``, *optional*):
-            True, if the administrator can edit stories posted by other users.
+            True, if the administrator can edit stories posted by other users, post stories to the chat page, pin chat stories, and access the chat's story archive.
 
         can_delete_stories (``bool``, *optional*):
             True, if the administrator can delete stories posted by other users
 
         can_manage_topics (``bool``, *optional*):
-            True, if the user is allowed to create, rename, close, and reopen forum topics.
-            supergroups only
+            True, if the user is allowed to create, rename, close, and reopen forum topics; for supergroups only.
+        
+        can_manage_direct_messages (``bool``, *optional*):
+            True, if the administrator can manage direct messages of the channel and decline suggested posts; for channels only.
+
     """
 
     def __init__(
@@ -95,6 +92,7 @@ class ChatPrivileges(Object):
         can_edit_stories: bool = False,
         can_delete_stories: bool = False,
         can_manage_topics: bool = False,  # supergroups only
+        can_manage_direct_messages: bool = False,
     ):
         super().__init__(None)
 
@@ -113,6 +111,7 @@ class ChatPrivileges(Object):
         self.can_edit_stories: bool = can_edit_stories
         self.can_delete_stories: bool = can_delete_stories
         self.can_manage_topics: bool = can_manage_topics
+        self.can_manage_direct_messages: bool = can_manage_direct_messages
 
     @staticmethod
     def _parse(admin_rights: "raw.base.ChatAdminRights") -> "ChatPrivileges":
@@ -133,7 +132,8 @@ class ChatPrivileges(Object):
             can_manage_topics=admin_rights.manage_topics,
             can_post_stories=admin_rights.post_stories,
             can_edit_stories=admin_rights.edit_stories,
-            can_delete_stories=admin_rights.delete_stories
+            can_delete_stories=admin_rights.delete_stories,
+            can_manage_direct_messages=admin_rights.manage_direct_messages
         )
 
     def write(self):
@@ -152,5 +152,6 @@ class ChatPrivileges(Object):
             manage_topics=self.can_manage_topics,
             post_stories=self.can_post_stories,
             edit_stories=self.can_edit_stories,
-            delete_stories=self.can_delete_stories
+            delete_stories=self.can_delete_stories,
+            manage_direct_messages=self.can_manage_direct_messages
         ) if self else raw.types.ChatAdminRights()

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -532,6 +532,8 @@ async def _get_reply_message_parameters(
         reply_to.monoforum_peer_id = await client.resolve_peer(
             reply_parameters.direct_messages_topic_id
         )
+    if reply_parameters.checklist_task_id:
+        reply_to.todo_item_id = reply_parameters.checklist_task_id
     return reply_to
 
 

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -499,10 +499,10 @@ async def _get_reply_message_parameters(
         )
     reply_to_message_id = reply_parameters.message_id
     if not reply_to_message_id:
-        if reply_parameters.direct_message_topic_id:
+        if reply_parameters.direct_messages_topic_id:
             return raw.types.InputReplyToMonoForum(
                 monoforum_peer_id=await client.resolve_peer(
-                    reply_parameters.direct_message_topic_id
+                    reply_parameters.direct_messages_topic_id
                 )
             )
         return reply_to
@@ -528,9 +528,9 @@ async def _get_reply_message_parameters(
         reply_to.reply_to_peer_id = await client.resolve_peer(reply_parameters.chat_id)
     if reply_parameters.quote_position:
         reply_to.quote_offset = reply_parameters.quote_position
-    if reply_parameters.direct_message_topic_id:
+    if reply_parameters.direct_messages_topic_id:
         reply_to.monoforum_peer_id = await client.resolve_peer(
-            reply_parameters.direct_message_topic_id
+            reply_parameters.direct_messages_topic_id
         )
     return reply_to
 

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -299,7 +299,7 @@ def get_peer_type(peer_id: int) -> str:
 
 def get_channel_id(peer_id: int) -> int:
     if MIN_MONOFORUM_CHANNEL_ID <= peer_id < MAX_MONOFORUM_CHANNEL_ID:
-        return peer_id
+        return MAX_CHANNEL_ID - peer_id
     return MAX_CHANNEL_ID - peer_id
 
 


### PR DESCRIPTION
[Rename direct_message_topic_id to direct_messages_topic_id in ReplyParameters. This parameter can be used to send a message to a direct messages chat topic.
Added the field checklist_task_id to the class [ReplyParameters](https://core.telegram.org/bots/api#replyparameters), allowing bots to reply to a specific checklist task.
Added the field reply_to_checklist_task_id to the class [Message](https://core.telegram.org/bots/api#message).
Added the field can_manage_direct_messages to ChatPrivileges
Added the field is_direct_messages to the classes [Chat](https://core.telegram.org/bots/api#chat) and [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo) which can be used to identify supergroups that are used as channel direct messages chats.
Added the field parent_chat to the class [ChatFullInfo](https://core.telegram.org/bots/api#chatfullinfo) which indicates the parent channel chat for a channel direct messages chat.
Add direct_messages_chat_id to Chat
