### PR TITLE
Add can_send_plain permission to ChatPermissions

### DIFF
--- a/pyrogram/methods/chats/get_dialogs.py
+++ b/pyrogram/methods/chats/get_dialogs.py
@@ -90,7 +90,13 @@ class GetDialogs:
                     continue
 
                 chat_id = utils.get_peer_id(message.peer_id)
-                messages[chat_id] = await types.Message._parse(self, message, users, chats, replies=self.fetch_replies)
+                messages[chat_id] = await types.Message._parse(
+                    self,
+                    message,
+                    users,
+                    chats,
+                    replies=self.fetch_replies
+                )
 
             dialogs = []
 

--- a/pyrogram/methods/chats/get_dialogs.py
+++ b/pyrogram/methods/chats/get_dialogs.py
@@ -29,7 +29,32 @@ class GetDialogs:
         pinned_only: bool = False,
         chat_list: int = 0
     ) -> Optional[AsyncGenerator["types.Dialog", None]]:
+        """Get a user's dialogs sequentially.
 
+        .. include:: /_includes/usable-by/users.rst
+
+        Parameters:
+            limit (``int``, *optional*):
+                Limits the number of dialogs to be retrieved.
+                By default, no limit is applied and all dialogs are returned.
+            
+            pinned_only (``bool``, *optional*):
+                Pass True if you want to get only pinned dialogs.
+                Defaults to False.
+            
+            chat_list (``int``, *optional*):
+                Chat list from which to get the dialogs; Only Main (0) and Archive (1) chat lists are supported. Defaults to (0) Main chat list.
+
+        Returns:
+            ``Generator``: A generator yielding :obj:`~pyrogram.types.Dialog` objects.
+
+        Example:
+            .. code-block:: python
+
+                # Iterate through all dialogs
+                async for dialog in app.get_dialogs():
+                    print(dialog.chat.first_name or dialog.chat.title)
+        """
         current = 0
         total = limit or (1 << 31) - 1
         request_limit = min(100, total)
@@ -76,10 +101,16 @@ class GetDialogs:
                     continue
 
                 parsed = types.Dialog._parse(self, dialog, messages, users, chats)
+                if parsed is None:
+                    continue
+                
+                if parsed.chat is None:
+                    continue
+                
                 if parsed.chat.id in seen_dialog_ids:
                     continue
+                
                 seen_dialog_ids.add(parsed.chat.id)
-
                 dialogs.append(parsed)
 
             if not dialogs:

--- a/pyrogram/methods/chats/get_dialogs.py
+++ b/pyrogram/methods/chats/get_dialogs.py
@@ -16,10 +16,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from asyncio import sleep
 from typing import AsyncGenerator, Optional
 
-from pyrogram import types, raw, utils
-from pyrogram.errors import ChannelPrivate, PeerIdInvalid
+from pyrogram import raw, types, utils
 
 
 class GetDialogs:
@@ -89,10 +89,7 @@ class GetDialogs:
                     continue
 
                 chat_id = utils.get_peer_id(message.peer_id)
-                try:
-                    messages[chat_id] = await types.Message._parse(self, message, users, chats)
-                except (ChannelPrivate, PeerIdInvalid):
-                    continue
+                messages[chat_id] = await types.Message._parse(self, message, users, chats, replies=self.fetch_replies)
 
             dialogs = []
 
@@ -126,6 +123,7 @@ class GetDialogs:
             offset_peer = await self.resolve_peer(last.chat.id)
 
             for dialog in dialogs:
+                await sleep(0)
                 yield dialog
                 current += 1
                 if current >= total:

--- a/pyrogram/methods/chats/get_dialogs.py
+++ b/pyrogram/methods/chats/get_dialogs.py
@@ -16,11 +16,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from asyncio import sleep
 from typing import AsyncGenerator, Optional
 
-import pyrogram
 from pyrogram import types, raw, utils
+from pyrogram.errors import ChannelPrivate, PeerIdInvalid
 
 
 class GetDialogs:
@@ -30,39 +29,16 @@ class GetDialogs:
         pinned_only: bool = False,
         chat_list: int = 0
     ) -> Optional[AsyncGenerator["types.Dialog", None]]:
-        """Get a user's dialogs sequentially.
 
-        .. include:: /_includes/usable-by/users.rst
-
-        Parameters:
-            limit (``int``, *optional*):
-                Limits the number of dialogs to be retrieved.
-                By default, no limit is applied and all dialogs are returned.
-            
-            pinned_only (``bool``, *optional*):
-                Pass True if you want to get only pinned dialogs.
-                Defaults to False.
-            
-            chat_list (``int``, *optional*):
-                Chat list from which to get the dialogs; Only Main (0) and Archive (1) chat lists are supported. Defaults to (0) Main chat list.
-
-        Returns:
-            ``Generator``: A generator yielding :obj:`~pyrogram.types.Dialog` objects.
-
-        Example:
-            .. code-block:: python
-
-                # Iterate through all dialogs
-                async for dialog in app.get_dialogs():
-                    print(dialog.chat.first_name or dialog.chat.title)
-        """
         current = 0
         total = limit or (1 << 31) - 1
-        limit = min(100, total)
+        request_limit = min(100, total)
 
         offset_date = 0
         offset_id = 0
         offset_peer = raw.types.InputPeerEmpty()
+
+        seen_dialog_ids = set()
 
         while True:
             r = await self.invoke(
@@ -70,7 +46,7 @@ class GetDialogs:
                     offset_date=offset_date,
                     offset_id=offset_id,
                     offset_peer=offset_peer,
-                    limit=limit,
+                    limit=request_limit,
                     hash=0,
                     exclude_pinned=not pinned_only,
                     folder_id=chat_list
@@ -88,13 +64,10 @@ class GetDialogs:
                     continue
 
                 chat_id = utils.get_peer_id(message.peer_id)
-                messages[chat_id] = await types.Message._parse(
-                    self,
-                    message,
-                    users,
-                    chats,
-                    replies=self.fetch_replies
-                )
+                try:
+                    messages[chat_id] = await types.Message._parse(self, message, users, chats)
+                except (ChannelPrivate, PeerIdInvalid):
+                    continue
 
             dialogs = []
 
@@ -102,22 +75,27 @@ class GetDialogs:
                 if not isinstance(dialog, raw.types.Dialog):
                     continue
 
-                dialogs.append(types.Dialog._parse(self, dialog, messages, users, chats))
+                parsed = types.Dialog._parse(self, dialog, messages, users, chats)
+                if parsed.chat.id in seen_dialog_ids:
+                    continue
+                seen_dialog_ids.add(parsed.chat.id)
+
+                dialogs.append(parsed)
 
             if not dialogs:
                 return
 
             last = dialogs[-1]
 
+            if last.top_message is None:
+                return
+
             offset_id = last.top_message.id
             offset_date = utils.datetime_to_timestamp(last.top_message.date)
             offset_peer = await self.resolve_peer(last.chat.id)
 
             for dialog in dialogs:
-                await sleep(0)
                 yield dialog
-
                 current += 1
-
                 if current >= total:
                     return

--- a/pyrogram/methods/chats/get_dialogs.py
+++ b/pyrogram/methods/chats/get_dialogs.py
@@ -19,6 +19,7 @@
 from asyncio import sleep
 from typing import AsyncGenerator, Optional
 
+import pyrogram
 from pyrogram import raw, types, utils
 
 

--- a/pyrogram/types/user_and_chats/chat_permissions.py
+++ b/pyrogram/types/user_and_chats/chat_permissions.py
@@ -28,6 +28,9 @@ class ChatPermissions(Object):
         can_send_messages (``bool``, *optional*):
             True, if the user is allowed to send text messages, contacts, giveaways, giveaway winners, invoices, locations and venues
 
+        can_send_plain (``bool``, *optional*):
+            True, if the user is allowed to send plain text messages
+
         can_send_audios (``bool``, *optional*):
             True, if the user is allowed to send audios
 
@@ -223,5 +226,4 @@ class ChatPermissions(Object):
             send_roundvideos=not permissions.can_send_video_notes,# TODO
             send_voices=not permissions.can_send_voice_notes,# TODO
             send_plain=not permissions.can_send_plain# TODO
-            # send_plain=# TODO
         )

--- a/pyrogram/types/user_and_chats/chat_permissions.py
+++ b/pyrogram/types/user_and_chats/chat_permissions.py
@@ -78,6 +78,7 @@ class ChatPermissions(Object):
     def __init__(
         self,
         *,
+        can_send_plain: bool = None,
         can_send_messages: bool = None,  # Text, contacts, giveaways, giveaway winners, invoices, locations and venues
         can_send_audios: bool = None,
         can_send_documents: bool = None,
@@ -96,6 +97,7 @@ class ChatPermissions(Object):
     ):
         super().__init__(None)
 
+        self.can_send_plain = can_send_plain
         self.can_send_messages = can_send_messages
         self.can_send_audios = can_send_audios
         self.can_send_documents = can_send_documents
@@ -114,6 +116,7 @@ class ChatPermissions(Object):
 
     @staticmethod
     def _parse(denied_permissions: "raw.base.ChatBannedRights") -> "ChatPermissions":
+        can_send_plain = False
         can_send_messages = False
         can_send_audios = False
         can_send_documents = False
@@ -131,6 +134,7 @@ class ChatPermissions(Object):
         can_send_media_messages = False
 
         if isinstance(denied_permissions, raw.types.ChatBannedRights):
+            can_send_plain = not denied_permissions.send_plain
             can_send_messages = not denied_permissions.send_messages
             can_send_polls = not denied_permissions.send_polls
             can_send_other_messages = any([
@@ -171,6 +175,7 @@ class ChatPermissions(Object):
                 can_send_voice_notes = can_send_media_messages
 
             return ChatPermissions(
+                can_send_plain=can_send_plain,
                 can_send_messages=can_send_messages,
                 can_send_audios=can_send_audios,
                 can_send_documents=can_send_documents,
@@ -217,5 +222,6 @@ class ChatPermissions(Object):
             send_videos=not permissions.can_send_videos,# TODO
             send_roundvideos=not permissions.can_send_video_notes,# TODO
             send_voices=not permissions.can_send_voice_notes,# TODO
+            send_plain=not permissions.can_send_plain# TODO
             # send_plain=# TODO
         )


### PR DESCRIPTION
This pull request adds support for the can_send_plain parameter to the ChatPermissions class, which controls whether a user can send plain text messages.
The class docstring has also been updated to reflect this new permission.